### PR TITLE
Reap all transaction from txpool for proposing a new block

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,3 @@
+
+ignore:
+  - "*/mock.go"

--- a/block/block.go
+++ b/block/block.go
@@ -108,7 +108,7 @@ func (b Block) Fingerprint() string {
 		b.data.Header.ProposerAddress().Fingerprint(),
 		b.data.Header.StateHash().Fingerprint(),
 		b.data.Header.CommittersHash().Fingerprint(),
-		b.data.TxIDs.Count(),
+		b.data.TxIDs.Len(),
 	)
 }
 

--- a/block/block_test.go
+++ b/block/block_test.go
@@ -34,6 +34,10 @@ func TestRandomBlock(t *testing.T) {
 	b, _ = GenerateTestBlock(nil)
 	b.data.Header.data.LastCommitHash = crypto.UndefHash
 	assert.Error(t, b.SanityCheck())
+
+	b, _ = GenerateTestBlock(nil)
+	b.data.LastCommit.data.Round = b.data.LastCommit.data.Round + 1
+	assert.Error(t, b.SanityCheck())
 }
 
 func TestMarshaling(t *testing.T) {

--- a/block/commit.go
+++ b/block/commit.go
@@ -70,13 +70,6 @@ func (commit *Commit) SanityCheck() error {
 	return nil
 }
 
-func (commit *Commit) Size() int {
-	if commit == nil {
-		return 0
-	}
-	return len(commit.data.Committers)
-}
-
 func (commit *Commit) Hash() crypto.Hash {
 	if commit == nil {
 		return crypto.UndefHash

--- a/block/txs.go
+++ b/block/txs.go
@@ -23,8 +23,15 @@ func NewTxIDs() TxIDs {
 		},
 	}
 }
-func (txs *TxIDs) Append(hash crypto.Hash) {
-	txs.data.IDs = append(txs.data.IDs, hash)
+func (txs *TxIDs) Append(id crypto.Hash) {
+	txs.data.IDs = append(txs.data.IDs, id)
+}
+
+func (txs *TxIDs) Prepend(id crypto.Hash) {
+	ids := make([]crypto.Hash, len(txs.data.IDs)+1)
+	ids[0] = id
+	copy(ids[1:], txs.data.IDs)
+	txs.data.IDs = ids
 }
 
 func (txs TxIDs) Hash() crypto.Hash {
@@ -37,10 +44,10 @@ func (txs TxIDs) IDs() []crypto.Hash {
 }
 
 func (txs TxIDs) IsEmpty() bool {
-	return txs.Count() == 0
+	return txs.Len() == 0
 }
 
-func (txs TxIDs) Count() int {
+func (txs TxIDs) Len() int {
 	return len(txs.data.IDs)
 }
 

--- a/block/txs_test.go
+++ b/block/txs_test.go
@@ -19,3 +19,17 @@ func TestTxsMerkle(t *testing.T) {
 	merkle := simpleMerkle.NewTreeFromHashes(data)
 	assert.Equal(t, b.Header().TxIDsHash(), merkle.Root())
 }
+
+func TestAppendAndPrepend(t *testing.T) {
+	ids := NewTxIDs()
+	h1 := crypto.GenerateTestHash()
+	h2 := crypto.GenerateTestHash()
+	h3 := crypto.GenerateTestHash()
+	h4 := crypto.GenerateTestHash()
+	ids.Append(h2)
+	ids.Append(h3)
+	ids.Prepend(h1)
+	ids.Append(h4)
+
+	assert.Equal(t, ids.data.IDs, []crypto.Hash{h1, h2, h3, h4})
+}

--- a/cmd/zarb/init.go
+++ b/cmd/zarb/init.go
@@ -69,8 +69,8 @@ func makeGenesis(workingDir string, chainName string) *genesis.Genesis {
 
 	// create  accounts for genesis
 	accs := make([]*account.Account, 5)
-	// Mintbase account
-	acc := account.NewAccount(crypto.MintbaseAddress, 0)
+	// Treasury account
+	acc := account.NewAccount(crypto.TreasuryAddress, 0)
 	acc.AddToBalance(21000000000000)
 
 	accs[0] = acc

--- a/cmd/zarb/start.go
+++ b/cmd/zarb/start.go
@@ -173,9 +173,6 @@ func Start() func(c *cli.Cmd) {
 					}
 					keyObj, _ = key.NewKey(pv.PublicKey().Address(), pv)
 				}
-
-				cmd.PrintInfoMsg("Validator address: %v", keyObj.Address())
-
 			}
 
 			// change working directory
@@ -202,7 +199,15 @@ func Start() func(c *cli.Cmd) {
 				return
 			}
 
+			validatorAddr := keyObj.Address()
+			mintbaseAddr := conf.State.MintbaseAddress
+			if mintbaseAddr == nil {
+				mintbaseAddr = &validatorAddr
+			}
 			cmd.PrintInfoMsg("You are running a zarb block chain node version: %v. Welcome! ", version.NodeVersion.String())
+			cmd.PrintInfoMsg("Validator address: %v", validatorAddr)
+			cmd.PrintInfoMsg("Mintbase address : %v", mintbaseAddr)
+			cmd.PrintInfoMsg("")
 
 			signer := keyObj.ToSigner()
 			node, err := node.NewNode(gen, conf, signer)

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -53,7 +53,7 @@ func newTestConsensus(t *testing.T, valID int) *Consensus {
 		vals[i] = val
 	}
 
-	acc := account.NewAccount(crypto.MintbaseAddress, 0)
+	acc := account.NewAccount(crypto.TreasuryAddress, 0)
 	acc.AddToBalance(21000000000000)
 
 	ch := make(chan *message.Message, 10)

--- a/crypto/address.go
+++ b/crypto/address.go
@@ -108,7 +108,7 @@ func (addr *Address) UnmarshalCBOR(bs []byte) error {
 /// METHODS
 
 func (addr *Address) SanityCheck() error {
-	if addr.EqualsTo(MintbaseAddress) {
+	if addr.EqualsTo(TreasuryAddress) {
 		return errors.Errorf(errors.ErrInvalidAddress, "")
 	}
 	return nil

--- a/crypto/address_test.go
+++ b/crypto/address_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMintbaseAddress(t *testing.T) {
+func TestTreasuryAddress(t *testing.T) {
 	expected, _ := hex.DecodeString("0000000000000000000000000000000000000000")
-	assert.Equal(t, MintbaseAddress.RawBytes(), expected)
+	assert.Equal(t, TreasuryAddress.RawBytes(), expected)
 }
 func TestMarshalingEmptyAddress(t *testing.T) {
 	addr1 := Address{}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -4,7 +4,7 @@ import (
 	"github.com/herumi/bls-go-binary/bls"
 )
 
-var MintbaseAddress = Address{data: addressData{Address: [AddressSize]byte{0}}}
+var TreasuryAddress = Address{data: addressData{Address: [AddressSize]byte{0}}}
 
 func init() {
 	if err := bls.Init(bls.BLS12_381); err != nil {

--- a/execution/execution_test.go
+++ b/execution/execution_test.go
@@ -3,25 +3,23 @@ package execution
 import (
 	"testing"
 
-	"github.com/zarbchain/zarb-go/sortition"
-
-	"github.com/zarbchain/zarb-go/logger"
-	"github.com/zarbchain/zarb-go/validator"
-
 	"github.com/stretchr/testify/assert"
-	"github.com/zarbchain/zarb-go/tx"
-
 	"github.com/zarbchain/zarb-go/account"
 	"github.com/zarbchain/zarb-go/crypto"
+	"github.com/zarbchain/zarb-go/logger"
 	"github.com/zarbchain/zarb-go/sandbox"
+	"github.com/zarbchain/zarb-go/sortition"
+	"github.com/zarbchain/zarb-go/tx"
+	"github.com/zarbchain/zarb-go/validator"
 )
 
 var tExec *Execution
-var tAcc1 *account.Account
 var tVal1 *validator.Validator
-var tPriv1 crypto.PrivateKey
-var tPub1 crypto.PublicKey
+var tAddr1, tAddr2 crypto.Address
+var tPriv1, tPriv2 crypto.PrivateKey
+var tPub1, tPub2 crypto.PublicKey
 var tSandbox *sandbox.MockSandbox
+var tTotalCoin int64
 
 func setup(t *testing.T) {
 	loggerConfig := logger.TestConfig()
@@ -29,15 +27,38 @@ func setup(t *testing.T) {
 
 	tSandbox = sandbox.NewMockSandbox()
 
-	tAcc1, tPriv1 = account.GenerateTestAccount(1)
+	acc1, priv1 := account.GenerateTestAccount(0)
+	tPriv1 = priv1
 	tPub1 = tPriv1.PublicKey()
-	tAcc1.SubtractFromBalance(tAcc1.Balance()) // make balance zero
-	tAcc1.AddToBalance(3000)
-	tSandbox.UpdateAccount(tAcc1)
+	tAddr1 = tPub1.Address()
+	acc1.SubtractFromBalance(acc1.Balance()) // make balance zero
+	acc1.AddToBalance(3000)
+	tSandbox.UpdateAccount(acc1)
+
+	acc2, priv2 := account.GenerateTestAccount(1)
+	tPriv2 = priv2
+	tPub2 = tPriv2.PublicKey()
+	tAddr2 = tPub2.Address()
+	acc2.SubtractFromBalance(acc2.Balance()) // make balance zero
+	acc2.AddToBalance(10000000000000000)
+	tSandbox.UpdateAccount(acc2)
+
 	tVal1 = validator.NewValidator(tPub1, 0, 0)
 	tSandbox.UpdateValidator(tVal1)
 
 	tExec = NewExecution(tSandbox)
+	tTotalCoin = 10000000000000000 + 3000
+}
+
+func checkTotalCoin(t *testing.T) {
+	total := int64(0)
+	for _, acc := range tSandbox.Accounts {
+		total += acc.Balance()
+	}
+	for _, val := range tSandbox.Validators {
+		total += val.Stake()
+	}
+	assert.Equal(t, total+tExec.accumulatedFee, tTotalCoin)
 }
 
 func TestExecuteSendTx(t *testing.T) {
@@ -51,30 +72,37 @@ func TestExecuteSendTx(t *testing.T) {
 	trx1.SetSignature(rcvPriv.Sign(trx1.SignBytes()))
 	assert.Error(t, tExec.Execute(trx1))
 
-	trx2 := tx.NewSendTx(stamp, tAcc1.Sequence()+2, tAcc1.Address(), rcvAddr, 1000, 1000, "invalid sequence", &tPub1, nil)
+	trx2 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAddr1)+2, tAddr1, rcvAddr, 1000, 1000, "invalid sequence", &tPub1, nil)
 	trx2.SetSignature(tPriv1.Sign(trx2.SignBytes()))
 	assert.Error(t, tExec.Execute(trx2))
 
-	trx3 := tx.NewSendTx(stamp, tAcc1.Sequence()+1, tAcc1.Address(), rcvAddr, 2001, 1000, "insufficient balance", &tPub1, nil)
+	trx3 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAddr1)+1, tAddr1, rcvAddr, 2001, 1000, "insufficient balance", &tPub1, nil)
 	trx3.SetSignature(tPriv1.Sign(trx3.SignBytes()))
 	assert.Error(t, tExec.Execute(trx3))
 
-	trx4 := tx.NewSendTx(stamp, tAcc1.Sequence()+1, tAcc1.Address(), rcvAddr, 1000, 999, "invalid fee", &tPub1, nil)
+	trx4 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAddr1)+1, tAddr1, rcvAddr, 1000, 999, "invalid fee", &tPub1, nil)
 	trx4.SetSignature(tPriv1.Sign(trx4.SignBytes()))
 	assert.Error(t, tExec.Execute(trx4))
 
-	trx5 := tx.NewSendTx(stamp, tAcc1.Sequence()+1, tAcc1.Address(), rcvAddr, 1000, 1000, "ok", &tPub1, nil)
+	trx5 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAddr1)+1, tAddr1, rcvAddr, 1000, 1000, "ok", &tPub1, nil)
 	trx5.SetSignature(tPriv1.Sign(trx5.SignBytes()))
 	assert.NoError(t, tExec.Execute(trx5))
+	assert.Equal(t, tSandbox.Account(tAddr1).Balance(), int64(1000))
+	assert.Equal(t, tSandbox.Account(rcvAddr).Balance(), int64(1000))
 
 	// Duplicated. Invalid sequence
 	assert.Error(t, tExec.Execute(trx5))
 
-	trx6 := tx.NewSendTx(stamp, tAcc1.Sequence()+1, tAcc1.Address(), rcvAddr, 1, 1000, "insufficient balance", &tPub1, nil)
+	trx6 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAddr1)+1, tAddr1, rcvAddr, 1, 1000, "insufficient balance", &tPub1, nil)
 	trx6.SetSignature(tPriv1.Sign(trx6.SignBytes()))
 	assert.Error(t, tExec.Execute(trx6))
-	assert.Equal(t, tSandbox.Account(tAcc1.Address()).Balance(), int64(1000))
-	assert.Equal(t, tSandbox.Account(rcvAddr).Balance(), int64(1000))
+
+	trx7 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAddr2)+1, tAddr2, rcvAddr, 5000000, 5000, "ok", &tPub2, nil)
+	trx7.SetSignature(tPriv2.Sign(trx7.SignBytes()))
+	assert.NoError(t, tExec.Execute(trx7))
+	assert.Equal(t, tExec.AccumulatedFee(), int64(6000))
+
+	checkTotalCoin(t)
 }
 
 func TestExecuteBondTx(t *testing.T) {
@@ -88,23 +116,26 @@ func TestExecuteBondTx(t *testing.T) {
 	trx1.SetSignature(valPriv.Sign(trx1.SignBytes()))
 	assert.Error(t, tExec.Execute(trx1))
 
-	trx2 := tx.NewBondTx(stamp, tAcc1.Sequence()+2, tAcc1.Address(), valPub, 1000, "invalid sequence", &tPub1, nil)
+	trx2 := tx.NewBondTx(stamp, tSandbox.AccSeq(tAddr1)+2, tAddr1, valPub, 1000, "invalid sequence", &tPub1, nil)
 	trx2.SetSignature(tPriv1.Sign(trx2.SignBytes()))
 	assert.Error(t, tExec.Execute(trx2))
 
-	trx3 := tx.NewBondTx(stamp, tAcc1.Sequence()+1, tAcc1.Address(), valPub, 3001, "insufficient balance", &tPub1, nil)
+	trx3 := tx.NewBondTx(stamp, tSandbox.AccSeq(tAddr1)+1, tAddr1, valPub, 3001, "insufficient balance", &tPub1, nil)
 	trx3.SetSignature(tPriv1.Sign(trx3.SignBytes()))
 	assert.Error(t, tExec.Execute(trx3))
 
-	trx4 := tx.NewBondTx(stamp, tAcc1.Sequence()+1, tAcc1.Address(), valPub, 1000, "ok", &tPub1, nil)
+	trx4 := tx.NewBondTx(stamp, tSandbox.AccSeq(tAddr1)+1, tAddr1, valPub, 1000, "ok", &tPub1, nil)
 	trx4.SetSignature(tPriv1.Sign(trx4.SignBytes()))
 	assert.NoError(t, tExec.Execute(trx4))
 
 	// Duplicated. Invalid sequence
 	assert.Error(t, tExec.Execute(trx4))
 
-	assert.Equal(t, tSandbox.Account(tAcc1.Address()).Balance(), int64(2000))
+	assert.Equal(t, tSandbox.Account(tAddr1).Balance(), int64(2000))
 	assert.Equal(t, tSandbox.Validator(valAddr).Stake(), int64(1000))
+	assert.Equal(t, tExec.AccumulatedFee(), int64(0))
+
+	checkTotalCoin(t)
 }
 
 func TestExecuteSortitionTx(t *testing.T) {
@@ -131,4 +162,24 @@ func TestExecuteSortitionTx(t *testing.T) {
 	assert.NotNil(t, trx3)
 	assert.NoError(t, tExec.Execute(trx3))
 
+	assert.Equal(t, tExec.AccumulatedFee(), int64(0))
+
+	checkTotalCoin(t)
+}
+
+func TestSendToSelf(t *testing.T) {
+	setup(t)
+
+	stamp := crypto.GenerateTestHash()
+	tSandbox.AppendStampAndUpdateHeight(100, stamp)
+
+	seq := tSandbox.AccSeq(tAddr1)
+	trx := tx.NewSendTx(stamp, seq+1, tAddr1, tAddr1, 1000, 1000, "ok", &tPub1, nil)
+	trx.SetSignature(tPriv1.Sign(trx.SignBytes()))
+	assert.NoError(t, tExec.Execute(trx))
+
+	assert.Equal(t, tSandbox.Account(tAddr1).Balance(), int64(2000)) // Crazy guy just want to pay fee!
+
+	acc := tSandbox.Account(tAddr1)
+	assert.Equal(t, acc.Sequence(), seq+1)
 }

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -35,7 +35,7 @@ func TestGenesisTestNet(t *testing.T) {
 		assert.Equal(t, v.Address(), v.PublicKey().Address())
 	}
 
-	assert.Equal(t, g.Accounts()[0].Address(), crypto.MintbaseAddress)
+	assert.Equal(t, g.Accounts()[0].Address(), crypto.TreasuryAddress)
 	assert.Equal(t, g.Accounts()[0].Balance(), int64(0x4A9B6384488000))
 
 	expected, _ := crypto.HashFromString("cabed9b2a3ac28b79cbe02cb521f462d6a2a37bba201618b377fe3a671f99fd2")

--- a/libs/linkedmap/linkedmap.go
+++ b/libs/linkedmap/linkedmap.go
@@ -4,8 +4,8 @@ import (
 	"container/list"
 )
 
-type pair struct {
-	key, value interface{}
+type Pair struct {
+	First, Second interface{}
 }
 
 type LinkedMap struct {
@@ -33,24 +33,24 @@ func (lm *LinkedMap) Has(key interface{}) bool {
 	return found
 }
 
-func (lm *LinkedMap) PushBack(key interface{}, value interface{}) {
-	el, found := lm.hashmap[key]
+func (lm *LinkedMap) PushBack(first interface{}, second interface{}) {
+	el, found := lm.hashmap[first]
 	if found {
-		// update the value
-		el.Value.(*pair).value = value
+		// update the second
+		el.Value.(*Pair).Second = second
 		return
 	}
 
-	el = lm.list.PushBack(&pair{key, value})
-	lm.hashmap[key] = el
+	el = lm.list.PushBack(&Pair{first, second})
+	lm.hashmap[first] = el
 
 	lm.prune()
 }
 
-func (lm *LinkedMap) Get(key interface{}) (interface{}, bool) {
-	el, found := lm.hashmap[key]
+func (lm *LinkedMap) Get(first interface{}) (interface{}, bool) {
+	el, found := lm.hashmap[first]
 	if found {
-		return el.Value.(*pair).value, true
+		return el.Value.(*Pair).Second, true
 
 	}
 	return nil, false
@@ -61,8 +61,8 @@ func (lm *LinkedMap) Last() (interface{}, interface{}) {
 	if el == nil {
 		return nil, nil
 	}
-	p := el.Value.(*pair)
-	return p.key, p.value
+	p := el.Value.(*Pair)
+	return p.First, p.Second
 }
 
 func (lm *LinkedMap) First() (interface{}, interface{}) {
@@ -70,15 +70,23 @@ func (lm *LinkedMap) First() (interface{}, interface{}) {
 	if el == nil {
 		return nil, nil
 	}
-	p := el.Value.(*pair)
-	return p.key, p.value
+	p := el.Value.(*Pair)
+	return p.First, p.Second
 }
 
-func (lm *LinkedMap) Remove(key interface{}) {
-	el, found := lm.hashmap[key]
+func (lm *LinkedMap) LastElement() *list.Element {
+	return lm.list.Back()
+}
+
+func (lm *LinkedMap) FirstElement() *list.Element {
+	return lm.list.Front()
+}
+
+func (lm *LinkedMap) Remove(first interface{}) {
+	el, found := lm.hashmap[first]
 	if found {
 		lm.list.Remove(el)
-		delete(lm.hashmap, el.Value.(*pair).key)
+		delete(lm.hashmap, el.Value.(*Pair).First)
 	}
 }
 
@@ -102,7 +110,7 @@ func (lm *LinkedMap) Clear() {
 func (lm *LinkedMap) prune() {
 	for lm.list.Len() > lm.capacity {
 		front := lm.list.Front()
-		key := front.Value.(*pair).key
+		key := front.Value.(*Pair).First
 		lm.list.Remove(front)
 		delete(lm.hashmap, key)
 	}

--- a/libs/linkedmap/linkedmap_test.go
+++ b/libs/linkedmap/linkedmap_test.go
@@ -14,39 +14,41 @@ func TestLinkedMap(t *testing.T) {
 		lm.PushBack(2, "b")
 		lm.PushBack(1, "a")
 
-		value, found := lm.Get(2)
-		assert.Equal(t, found, true)
-		assert.Equal(t, value, "b")
+		v, ok := lm.Get(2)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, v, "b")
 
-		value, found = lm.Get(5)
-		assert.Equal(t, found, false)
-		assert.Equal(t, value, nil)
+		v, ok = lm.Get(5)
+		assert.Equal(t, ok, false)
+		assert.Equal(t, v, nil)
 	})
 
 	t.Run("Should removes item", func(t *testing.T) {
 		lm := NewLinkedMap(4)
 
+		lm.PushBack(0, "-")
 		lm.PushBack(2, "b")
 		lm.PushBack(1, "a")
 		lm.Remove(2)
 
-		value, found := lm.Get(2)
-		assert.Equal(t, found, false)
-		assert.Equal(t, value, nil)
+		v, ok := lm.Get(2)
+		assert.Equal(t, ok, false)
+		assert.Equal(t, v, nil)
+
 	})
 
-	t.Run("Should updates value", func(t *testing.T) {
+	t.Run("Should updates v", func(t *testing.T) {
 		lm := NewLinkedMap(4)
 
 		lm.PushBack(0xa, "a")
 		lm.PushBack(0xa, "A")
 
-		value, found := lm.Get(0xa)
-		assert.Equal(t, found, true)
-		assert.Equal(t, value, "A")
+		v, ok := lm.Get(0xa)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, v, "A")
 	})
 
-	t.Run("Should prunces oldest item", func(t *testing.T) {
+	t.Run("Should prunes oldest item", func(t *testing.T) {
 		lm := NewLinkedMap(4)
 
 		lm.PushBack(1, "a")
@@ -54,18 +56,18 @@ func TestLinkedMap(t *testing.T) {
 		lm.PushBack(3, "c")
 		lm.PushBack(4, "d")
 
-		value, found := lm.Get(1)
-		assert.Equal(t, found, true)
-		assert.Equal(t, value, "a")
+		v, ok := lm.Get(1)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, v, "a")
 
 		lm.PushBack(5, "e")
 
-		value, found = lm.Get(1)
-		assert.Equal(t, found, false)
-		assert.Equal(t, value, nil)
+		v, ok = lm.Get(1)
+		assert.Equal(t, ok, false)
+		assert.Equal(t, v, nil)
 	})
 
-	t.Run("Should prunces by changing capacity", func(t *testing.T) {
+	t.Run("Should prunes by changing capacity", func(t *testing.T) {
 		lm := NewLinkedMap(4)
 
 		lm.PushBack(1, "a")
@@ -75,16 +77,16 @@ func TestLinkedMap(t *testing.T) {
 
 		lm.SetCapacity(6)
 
-		value, found := lm.Get(2)
-		assert.Equal(t, found, true)
-		assert.Equal(t, value, "b")
+		v, ok := lm.Get(2)
+		assert.Equal(t, ok, true)
+		assert.Equal(t, v, "b")
 
 		lm.SetCapacity(2)
 		assert.True(t, lm.Full())
 
-		value, found = lm.Get(2)
-		assert.Equal(t, found, false)
-		assert.Equal(t, value, nil)
+		v, ok = lm.Get(2)
+		assert.Equal(t, ok, false)
+		assert.Equal(t, v, nil)
 	})
 
 	t.Run("Should returns first", func(t *testing.T) {
@@ -93,7 +95,10 @@ func TestLinkedMap(t *testing.T) {
 		lm.PushBack(1, "a")
 		lm.PushBack(2, "b")
 		lm.PushBack(3, "c")
-		lm.PushBack(4, "d")
+		lm.PushBack(4, "d") // pruning happens here
+
+		el := lm.FirstElement()
+		assert.Equal(t, el.Value, &Pair{2, "b"})
 
 		k, v := lm.First()
 		assert.Equal(t, k, 2)
@@ -106,11 +111,38 @@ func TestLinkedMap(t *testing.T) {
 		lm.PushBack(1, "a")
 		lm.PushBack(2, "b")
 		lm.PushBack(3, "c")
-		lm.PushBack(4, "d")
+		lm.PushBack(4, "d") // pruning happens here
+
+		el := lm.LastElement()
+		assert.Equal(t, el.Value, &Pair{4, "d"})
 
 		k, v := lm.Last()
 		assert.Equal(t, k, 4)
 		assert.Equal(t, v, "d")
 	})
 
+	t.Run("Deletd first ", func(t *testing.T) {
+		lm := NewLinkedMap(3)
+
+		lm.PushBack(1, "a")
+		lm.PushBack(2, "b")
+		lm.PushBack(3, "c")
+
+		lm.Remove(1)
+
+		el := lm.FirstElement()
+		assert.Equal(t, el.Value, &Pair{2, "b"})
+	})
+
+	t.Run("Delete last", func(t *testing.T) {
+		lm := NewLinkedMap(3)
+
+		lm.PushBack(1, "a")
+		lm.PushBack(2, "b")
+		lm.PushBack(3, "c")
+
+		lm.Remove(3)
+		el := lm.LastElement()
+		assert.Equal(t, el.Value, &Pair{2, "b"})
+	})
 }

--- a/message/txs.go
+++ b/message/txs.go
@@ -7,10 +7,10 @@ import (
 )
 
 type TxsPayload struct {
-	Txs []tx.Tx `cbor:"2,keyasint"`
+	Txs []*tx.Tx `cbor:"2,keyasint"`
 }
 
-func NewTxsMessage(txs []tx.Tx) *Message {
+func NewTxsMessage(txs []*tx.Tx) *Message {
 	return &Message{
 		Type: PayloadTypeTxs,
 		Payload: &TxsPayload{

--- a/message/txs_req.go
+++ b/message/txs_req.go
@@ -8,20 +8,20 @@ import (
 )
 
 type TxsReqPayload struct {
-	Hashes []crypto.Hash `cbor:"1,keyasint"`
+	IDs []crypto.Hash `cbor:"1,keyasint"`
 }
 
-func NewTxsReqMessage(hashes []crypto.Hash) *Message {
+func NewTxsReqMessage(ids []crypto.Hash) *Message {
 	return &Message{
 		Type: PayloadTypeTxsReq,
 		Payload: &TxsReqPayload{
-			Hashes: hashes,
+			IDs: ids,
 		},
 	}
 }
 
 func (p *TxsReqPayload) SanityCheck() error {
-	if len(p.Hashes) == 0 {
+	if len(p.IDs) == 0 {
 		return errors.Errorf(errors.ErrInvalidMessage, "Empty list")
 	}
 	return nil
@@ -33,7 +33,7 @@ func (p *TxsReqPayload) Type() PayloadType {
 
 func (p *TxsReqPayload) Fingerprint() string {
 	var s string
-	for _, h := range p.Hashes {
+	for _, h := range p.IDs {
 		s += fmt.Sprintf("%v ", h.Fingerprint())
 	}
 	return fmt.Sprintf("%v", s)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestRunningNode(t *testing.T) {
 	_, pb, pv := crypto.RandomKeyPair()
-	acc := account.NewAccount(crypto.MintbaseAddress, 0)
+	acc := account.NewAccount(crypto.TreasuryAddress, 0)
 	acc.AddToBalance(21000000000000)
 	val := validator.NewValidator(pb, 0, 0)
 	gen := genesis.MakeGenesis("test", time.Now(), []*account.Account{acc}, []*validator.Validator{val}, 1)

--- a/param/param.go
+++ b/param/param.go
@@ -3,23 +3,25 @@ package param
 import "time"
 
 type Params struct {
-	BlockTime                 time.Duration
-	MaximumPower              int
-	SubsidyReductionInterval  int
-	MaximumMemoLength         int
-	FeeFraction               float64
-	MinimumFee                int64
-	TransactionToLiveInterval int
+	BlockTime                  time.Duration
+	MaximumTransactionPerBlock int
+	MaximumPower               int
+	SubsidyReductionInterval   int
+	MaximumMemoLength          int
+	FeeFraction                float64
+	MinimumFee                 int64
+	TransactionToLiveInterval  int
 }
 
 func NewParams() Params {
 	return Params{
-		BlockTime:                 10 * time.Second,
-		MaximumPower:              21,
-		SubsidyReductionInterval:  2100000,
-		MaximumMemoLength:         1024,
-		FeeFraction:               0.001,
-		MinimumFee:                1000,
-		TransactionToLiveInterval: 500,
+		BlockTime:                  10 * time.Second,
+		MaximumTransactionPerBlock: 1000,
+		MaximumPower:               21,
+		SubsidyReductionInterval:   2100000,
+		MaximumMemoLength:          1024,
+		FeeFraction:                0.001,
+		MinimumFee:                 1000,
+		TransactionToLiveInterval:  500,
 	}
 }

--- a/sandbox/mock.go
+++ b/sandbox/mock.go
@@ -11,8 +11,8 @@ var _ Sandbox = &MockSandbox{}
 
 // MockSandbox is a testing mock for sandbox
 type MockSandbox struct {
-	Accounts       map[crypto.Address]*account.Account
-	Validators     map[crypto.Address]*validator.Validator
+	Accounts       map[crypto.Address]account.Account
+	Validators     map[crypto.Address]validator.Validator
 	Stamps         map[crypto.Hash]int
 	CurrentHeight_ int
 	TTLInterval    int
@@ -27,8 +27,8 @@ type MockSandbox struct {
 func NewMockSandbox() *MockSandbox {
 	_, _, priv := crypto.GenerateTestKeyPair()
 	return &MockSandbox{
-		Accounts:       make(map[crypto.Address]*account.Account),
-		Validators:     make(map[crypto.Address]*validator.Validator),
+		Accounts:       make(map[crypto.Address]account.Account),
+		Validators:     make(map[crypto.Address]validator.Validator),
 		Stamps:         make(map[crypto.Hash]int),
 		TTLInterval:    4,
 		MaxMemoLength_: 1024,
@@ -38,7 +38,11 @@ func NewMockSandbox() *MockSandbox {
 	}
 }
 func (m *MockSandbox) Account(addr crypto.Address) *account.Account {
-	return m.Accounts[addr]
+	acc, ok := m.Accounts[addr]
+	if !ok {
+		return nil
+	}
+	return &acc
 }
 func (m *MockSandbox) MakeNewAccount(addr crypto.Address) *account.Account {
 	a := account.NewAccount(addr, m.TotalAccount)
@@ -46,10 +50,14 @@ func (m *MockSandbox) MakeNewAccount(addr crypto.Address) *account.Account {
 	return a
 }
 func (m *MockSandbox) UpdateAccount(acc *account.Account) {
-	m.Accounts[acc.Address()] = acc
+	m.Accounts[acc.Address()] = *acc
 }
 func (m *MockSandbox) Validator(addr crypto.Address) *validator.Validator {
-	return m.Validators[addr]
+	val, ok := m.Validators[addr]
+	if !ok {
+		return nil
+	}
+	return &val
 }
 func (m *MockSandbox) MakeNewValidator(pub crypto.PublicKey) *validator.Validator {
 	v := validator.NewValidator(pub, m.TotalAccount, m.CurrentHeight_+1)
@@ -57,7 +65,7 @@ func (m *MockSandbox) MakeNewValidator(pub crypto.PublicKey) *validator.Validato
 	return v
 }
 func (m *MockSandbox) UpdateValidator(val *validator.Validator) {
-	m.Validators[val.Address()] = val
+	m.Validators[val.Address()] = *val
 
 }
 func (m *MockSandbox) AddToSet(crypto.Hash, crypto.Address) error {
@@ -92,4 +100,8 @@ func (m *MockSandbox) MinFee() int64 {
 func (m *MockSandbox) AppendStampAndUpdateHeight(height int, stamp crypto.Hash) {
 	m.Stamps[stamp] = height
 	m.CurrentHeight_ = height + 1
+}
+
+func (m *MockSandbox) AccSeq(a crypto.Address) int {
+	return m.Accounts[a].Sequence()
 }

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -289,6 +289,9 @@ func (sb *SandboxConcrete) RecentBlockHeight(hash crypto.Hash) int {
 
 func (sb *SandboxConcrete) lastHeight() int {
 	_, v := sb.recentBlocks.Last()
+	if v == nil {
+		return -1
+	}
 	return v.(int) + 1
 }
 

--- a/sandbox/sandbox_test.go
+++ b/sandbox/sandbox_test.go
@@ -27,7 +27,7 @@ func setup(t *testing.T) {
 	tStore = store.NewMockStore()
 
 	_, pb, priv := crypto.GenerateTestKeyPair()
-	acc := account.NewAccount(crypto.MintbaseAddress, 0)
+	acc := account.NewAccount(crypto.TreasuryAddress, 0)
 	acc.AddToBalance(21000000000000)
 	val := validator.NewValidator(pb, 0, 0)
 	tValSigner = crypto.NewSigner(priv)
@@ -54,7 +54,7 @@ func TestAccountChange(t *testing.T) {
 		assert.Nil(t, tSandbox.Account(invAddr))
 	})
 
-	t.Run("Retreive an account from store, modify it and commit it", func(t *testing.T) {
+	t.Run("Retrieve an account from store, modify it and commit it", func(t *testing.T) {
 		acc1, _ := account.GenerateTestAccount(0)
 		tStore.UpdateAccount(acc1)
 
@@ -94,7 +94,7 @@ func TestValidatorChange(t *testing.T) {
 		assert.Nil(t, tSandbox.Validator(invAddr))
 	})
 
-	t.Run("Retreive an validator from store, modify it and commit it", func(t *testing.T) {
+	t.Run("Retrieve an validator from store, modify it and commit it", func(t *testing.T) {
 		val1, _ := validator.GenerateTestValidator(0)
 		tStore.UpdateValidator(val1)
 
@@ -199,7 +199,7 @@ func TestCreateDuplicated(t *testing.T) {
 				t.Errorf("The code did not panic")
 			}
 		}()
-		addr := crypto.MintbaseAddress
+		addr := crypto.TreasuryAddress
 		tSandbox.MakeNewAccount(addr)
 	})
 

--- a/state/config.go
+++ b/state/config.go
@@ -1,12 +1,14 @@
 package state
 
 import (
+	"github.com/zarbchain/zarb-go/crypto"
 	"github.com/zarbchain/zarb-go/store"
 )
 
 // Config holds the configuration of the node
 type Config struct {
-	Store *store.Config
+	MintbaseAddress *crypto.Address
+	Store           *store.Config
 }
 
 // DefaultConfig instantiates the default configuration for the node

--- a/state/execution.go
+++ b/state/execution.go
@@ -18,15 +18,15 @@ func (st *state) executeBlock(block block.Block) ([]tx.CommittedTx, error) {
 		if err := trx.SanityCheck(); err != nil {
 			return nil, err
 		}
-		// Only first transaction should be mintbase transaction
-		isMintbaseTx := (i == 0)
-		if isMintbaseTx {
-			if !trx.IsMintbaseTx() {
-				return nil, errors.Errorf(errors.ErrInvalidTx, "Not a mintbase transaction")
+		// Only first transaction should be subsidy transaction
+		isSubsidyTx := (i == 0)
+		if isSubsidyTx {
+			if !trx.IsSubsidyTx() {
+				return nil, errors.Errorf(errors.ErrInvalidTx, "Not a subsidy transaction")
 			}
 		} else {
-			if trx.IsMintbaseTx() {
-				return nil, errors.Errorf(errors.ErrInvalidTx, "Duplicated mintbase transaction")
+			if trx.IsSubsidyTx() {
+				return nil, errors.Errorf(errors.ErrInvalidTx, "Duplicated subsidy transaction")
 			}
 		}
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4,6 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/zarbchain/zarb-go/tx"
+
+	"github.com/zarbchain/zarb-go/tx/payload"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
@@ -18,20 +22,20 @@ import (
 	"github.com/zarbchain/zarb-go/vote"
 )
 
-var mockTxPool *txpool.MockTxPool
-var gen *genesis.Genesis
-var valSigner crypto.Signer
+var tTxPool *txpool.MockTxPool
+var tGenDoc *genesis.Genesis
+var tValSigner crypto.Signer
 
 func setup(t *testing.T) {
-	mockTxPool = txpool.NewMockTxPool()
+	tTxPool = txpool.NewMockTxPool()
 
 	_, pb, priv := crypto.GenerateTestKeyPair()
-	acc := account.NewAccount(crypto.MintbaseAddress, 0)
+	acc := account.NewAccount(crypto.TreasuryAddress, 0)
 	acc.AddToBalance(21000000000000)
 	val := validator.NewValidator(pb, 0, 0)
 	val.AddToStake(util.RandInt64(10000000))
-	gen = genesis.MakeGenesis("test", time.Now(), []*account.Account{acc}, []*validator.Validator{val}, 1)
-	valSigner = crypto.NewSigner(priv)
+	tGenDoc = genesis.MakeGenesis("test", time.Now(), []*account.Account{acc}, []*validator.Validator{val}, 1)
+	tValSigner = crypto.NewSigner(priv)
 
 	loggerConfig := logger.TestConfig()
 	logger.InitLogger(loggerConfig)
@@ -45,27 +49,27 @@ func mockState(t *testing.T, signer *crypto.Signer) (*state, crypto.Address) {
 	}
 
 	stateConfig := TestConfig()
-	st, err := LoadOrNewState(stateConfig, gen, *signer, mockTxPool)
+	st, err := LoadOrNewState(stateConfig, tGenDoc, *signer, tTxPool)
 	require.NoError(t, err)
 	s, _ := st.(*state)
 
 	return s, signer.Address()
 }
 
-func TestProposeBlockValidation(t *testing.T) {
+func TestProposeBlockAndValidation(t *testing.T) {
 	setup(t)
 
-	st, _ := mockState(t, &valSigner)
+	st, _ := mockState(t, &tValSigner)
 	block := st.ProposeBlock()
 	err := st.ValidateBlock(block)
 	require.NoError(t, err)
 }
 
 func proposeAndSignBlock(t *testing.T, st *state) (block.Block, block.Commit) {
-	addr := valSigner.Address()
+	addr := tValSigner.Address()
 	b := st.ProposeBlock()
 	v := vote.NewPrecommit(1, 0, b.Hash(), addr)
-	sig := valSigner.Sign(v.SignBytes())
+	sig := tValSigner.Sign(v.SignBytes())
 	c := block.NewCommit(0, []block.Committer{{Status: 1, Address: addr}}, *sig)
 
 	return b, *c
@@ -74,8 +78,8 @@ func proposeAndSignBlock(t *testing.T, st *state) (block.Block, block.Commit) {
 func TestLoadState(t *testing.T) {
 	setup(t)
 
-	st1, _ := mockState(t, &valSigner)
-	st2, _ := mockState(t, &valSigner)
+	st1, _ := mockState(t, &tValSigner)
+	st2, _ := mockState(t, &tValSigner)
 
 	// Add this dummy acc and val for testing purpose
 	dummyAcc, _ := account.GenerateTestAccount(1)
@@ -98,7 +102,7 @@ func TestLoadState(t *testing.T) {
 	assert.NoError(t, st2.Close())
 
 	// Load last state info
-	st3, err := LoadOrNewState(st2.config, gen, valSigner, mockTxPool)
+	st3, err := LoadOrNewState(st2.config, tGenDoc, tValSigner, tTxPool)
 	require.NoError(t, err)
 
 	b, c := proposeAndSignBlock(t, st1)
@@ -123,13 +127,60 @@ func TestBlockSubsidy(t *testing.T) {
 	assert.Equal(t, int64(1.25*1e8), calcBlockSubsidy((2*interval), 210000))
 }
 
+func TestBlockSubsidyTx(t *testing.T) {
+	setup(t)
+	st, _ := mockState(t, &tValSigner)
+
+	trx := st.createSubsidyTx(7)
+	assert.True(t, trx.IsSubsidyTx())
+	assert.Equal(t, trx.Payload().Value(), calcBlockSubsidy(1, st.params.SubsidyReductionInterval)+7)
+	assert.Equal(t, trx.Payload().(*payload.SendPayload).Receiver, tValSigner.Address())
+
+	addr, _, _ := crypto.GenerateTestKeyPair()
+	st.config.MintbaseAddress = &addr
+	trx = st.createSubsidyTx(0)
+	assert.Equal(t, trx.Payload().(*payload.SendPayload).Receiver, addr)
+}
+
 func TestApplyBlocks(t *testing.T) {
 	setup(t)
 
-	st, _ := mockState(t, &valSigner)
+	st, _ := mockState(t, &tValSigner)
 	b1, c1 := proposeAndSignBlock(t, st)
 	invBlock, _ := block.GenerateTestBlock(nil)
 	assert.Error(t, st.ApplyBlock(1, invBlock, c1))
 	assert.Error(t, st.ApplyBlock(2, b1, c1))
+}
 
+func TestProposeBlock(t *testing.T) {
+	setup(t)
+
+	st1, _ := mockState(t, &tValSigner)
+	st2, _ := mockState(t, nil)
+
+	b1, c1 := proposeAndSignBlock(t, st1)
+	assert.NoError(t, st1.ApplyBlock(1, b1, c1))
+
+	invSubsidyTx := st2.createSubsidyTx(100)
+	invSendTx, _ := tx.GenerateTestSendTx()
+	invBondTx, _ := tx.GenerateTestBondTx()
+	invSortitionTx, _ := tx.GenerateTestSortitionTx()
+
+	pub := tValSigner.PublicKey()
+	trx1 := tx.NewSendTx(b1.Hash(), 1, tValSigner.Address(), tValSigner.Address(), 1, 1000, "", &pub, nil)
+	tValSigner.SignMsg(trx1)
+
+	trx2 := tx.NewBondTx(b1.Hash(), 2, tValSigner.Address(), pub, 1, "", &pub, nil)
+	tValSigner.SignMsg(trx2)
+
+	tTxPool.AppendTx(invSendTx)
+	tTxPool.AppendTx(invBondTx)
+	tTxPool.AppendTx(invSortitionTx)
+	tTxPool.AppendTx(invSubsidyTx)
+	tTxPool.AppendTx(trx1)
+	tTxPool.AppendTx(trx2)
+
+	b2 := st1.ProposeBlock()
+	assert.Equal(t, b2.Header().LastBlockHash(), b1.Hash())
+	assert.Equal(t, b2.TxIDs().IDs()[1:], []crypto.Hash{trx1.ID(), trx2.ID()})
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -173,12 +173,12 @@ func TestProposeBlock(t *testing.T) {
 	trx2 := tx.NewBondTx(b1.Hash(), 2, tValSigner.Address(), pub, 1, "", &pub, nil)
 	tValSigner.SignMsg(trx2)
 
-	tTxPool.AppendTx(invSendTx)
-	tTxPool.AppendTx(invBondTx)
-	tTxPool.AppendTx(invSortitionTx)
-	tTxPool.AppendTx(invSubsidyTx)
-	tTxPool.AppendTx(trx1)
-	tTxPool.AppendTx(trx2)
+	assert.NoError(t, tTxPool.AppendTx(invSendTx))
+	assert.NoError(t, tTxPool.AppendTx(invBondTx))
+	assert.NoError(t, tTxPool.AppendTx(invSortitionTx))
+	assert.NoError(t, tTxPool.AppendTx(invSubsidyTx))
+	assert.NoError(t, tTxPool.AppendTx(trx1))
+	assert.NoError(t, tTxPool.AppendTx(trx2))
 
 	b2 := st1.ProposeBlock()
 	assert.Equal(t, b2.Header().LastBlockHash(), b1.Hash())

--- a/store/account_test.go
+++ b/store/account_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/zarbchain/zarb-go/util"
 )
 
-func TestRetreiveAccount(t *testing.T) {
+func TestRetrieveAccount(t *testing.T) {
 	store, _ := newAccountStore(util.TempDirPath())
 
 	acc, _ := account.GenerateTestAccount(util.RandInt(10000))

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/zarbchain/zarb-go/util"
 )
 
-func TestRetreiveBlockAndTransactions(t *testing.T) {
+func TestRetrieveBlockAndTransactions(t *testing.T) {
 	conf := TestConfig()
 	store, err := NewStore(conf)
 	assert.NoError(t, err)

--- a/store/validator_test.go
+++ b/store/validator_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/zarbchain/zarb-go/validator"
 )
 
-func TestRetreiveValidator(t *testing.T) {
+func TestRetrieveValidator(t *testing.T) {
 	store, _ := newValidatorStore(util.TempDirPath())
 
 	val, _ := validator.GenerateTestValidator(util.RandInt(1000))

--- a/sync/dispatch.go
+++ b/sync/dispatch.go
@@ -18,7 +18,7 @@ func (syncer *Synchronizer) sendBlocks(from, to int) {
 	}
 
 	// Help peer to catch up
-	txs := make([]tx.Tx, 0)
+	txs := make([]*tx.Tx, 0)
 	blocks := make([]block.Block, to-from+1)
 	for h := from; h <= to; h++ {
 		b, err := syncer.store.Block(h)
@@ -30,7 +30,7 @@ func (syncer *Synchronizer) sendBlocks(from, to int) {
 		for _, id := range ids {
 			ctrx, _ := syncer.store.Transaction(id)
 			if ctrx != nil {
-				txs = append(txs, *ctrx.Tx)
+				txs = append(txs, ctrx.Tx)
 			} else {
 				syncer.logger.Warn("We don't have transaction for the block", "id", id.Fingerprint())
 			}
@@ -70,7 +70,7 @@ func (syncer *Synchronizer) broadcastBlocks(from int, blocks []block.Block, last
 	syncer.publishMessage(msg)
 }
 
-func (syncer *Synchronizer) broadcastTxs(txs []tx.Tx) {
+func (syncer *Synchronizer) broadcastTxs(txs []*tx.Tx) {
 	if len(txs) == 0 {
 		return
 	}

--- a/sync/fetch.go
+++ b/sync/fetch.go
@@ -138,8 +138,8 @@ func (syncer *Synchronizer) processBlocksPayload(pld *message.BlocksPayload) {
 }
 
 func (syncer *Synchronizer) processTxsReqPayload(pld *message.TxsReqPayload) {
-	txs := make([]tx.Tx, 0, len(pld.Hashes))
-	for _, h := range pld.Hashes {
+	txs := make([]*tx.Tx, 0, len(pld.IDs))
+	for _, h := range pld.IDs {
 		trx := syncer.txPool.PendingTx(h)
 		if trx == nil {
 			// Do we have this transaction in our store?
@@ -149,7 +149,7 @@ func (syncer *Synchronizer) processTxsReqPayload(pld *message.TxsReqPayload) {
 			}
 		}
 		if trx != nil {
-			txs = append(txs, *trx)
+			txs = append(txs, trx)
 		}
 	}
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -127,7 +127,7 @@ func (syncer *Synchronizer) broadcastLoop() {
 	}
 }
 func (syncer *Synchronizer) Fingerprint() string {
-	return fmt.Sprintf("{☍ %d ⛲ %d height %d}",
+	return fmt.Sprintf("{☍ %d ⛲ %d ↥ %d}",
 		syncer.stats.PeersCount(),
 		syncer.blockPool.BlockLen(),
 		syncer.stats.MaxHeight())

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -28,7 +28,7 @@ var (
 	genDoc       *genesis.Genesis
 	ctx          context.Context
 	txPool       *txpool.MockTxPool
-	validTxs     []tx.Tx
+	validTxs     []*tx.Tx
 	validBlocks  []block.Block
 	validCommits []block.Commit
 	totalBlocks  int
@@ -39,7 +39,7 @@ var (
 func setup(t *testing.T) {
 	syncConf = TestConfig()
 	val, key := validator.GenerateTestValidator(0)
-	acc := account.NewAccount(crypto.MintbaseAddress, 0)
+	acc := account.NewAccount(crypto.TreasuryAddress, 0)
 	acc.AddToBalance(21000000000000)
 	signer = crypto.NewSigner(key)
 	genDoc = genesis.MakeGenesis("test", time.Now(), []*account.Account{acc}, []*validator.Validator{val}, 1)
@@ -50,12 +50,12 @@ func setup(t *testing.T) {
 
 	blockCount := 12
 	validBlocks = make([]block.Block, 0, blockCount)
-	validTxs = make([]tx.Tx, 0, blockCount)
+	validTxs = make([]*tx.Tx, 0, blockCount)
 	for i := 0; i < blockCount; i++ {
 		b := st.ProposeBlock()
 		id := b.TxIDs().IDs()[0]
 		trx := txPool.PendingTx(id)
-		validTxs = append(validTxs, *trx)
+		validTxs = append(validTxs, trx)
 
 		v := vote.NewPrecommit(i+1, 0, b.Hash(), signer.Address())
 		signer.SignMsg(v)

--- a/tx/factory.go
+++ b/tx/factory.go
@@ -5,11 +5,11 @@ import (
 	"github.com/zarbchain/zarb-go/tx/payload"
 )
 
-func NewMintbaseTx(stamp crypto.Hash, sequence int, receiver crypto.Address, amount int64, memo string) *Tx {
+func NewSubsidyTx(stamp crypto.Hash, sequence int, receiver crypto.Address, amount int64, memo string) *Tx {
 	return NewSendTx(
 		stamp,
 		sequence,
-		crypto.MintbaseAddress,
+		crypto.TreasuryAddress,
 		receiver,
 		amount,
 		0,

--- a/tx/payload/bond.go
+++ b/tx/payload/bond.go
@@ -40,7 +40,7 @@ func (p *BondPayload) SanityCheck() error {
 }
 
 func (p *BondPayload) Fingerprint() string {
-	return fmt.Sprintf("{Bond: %v->%v 🪙 %v",
+	return fmt.Sprintf("{Bond: %v->%v 🧷 %v",
 		p.Bonder.Fingerprint(),
 		p.Validator.Address().Fingerprint(),
 		p.Stake)

--- a/tx/payload/send.go
+++ b/tx/payload/send.go
@@ -37,7 +37,7 @@ func (p *SendPayload) SanityCheck() error {
 }
 
 func (p *SendPayload) Fingerprint() string {
-	return fmt.Sprintf("{Send: %v->%v 🪙 %v",
+	return fmt.Sprintf("{Send: %v->%v 💸 %v",
 		p.Sender.Fingerprint(),
 		p.Receiver.Fingerprint(),
 		p.Amount)

--- a/tx/receipt.go
+++ b/tx/receipt.go
@@ -3,10 +3,9 @@ package tx
 import (
 	"encoding/json"
 
-	"github.com/zarbchain/zarb-go/errors"
-
 	"github.com/fxamacker/cbor/v2"
 	"github.com/zarbchain/zarb-go/crypto"
+	"github.com/zarbchain/zarb-go/errors"
 )
 
 const (

--- a/tx/receipt_test.go
+++ b/tx/receipt_test.go
@@ -13,7 +13,7 @@ import (
 func TestEncodingReceipt(t *testing.T) {
 	r1 := Receipt{
 		data: receiptData{
-			TxID:    crypto.GenerateTestHash(),
+			TxID:      crypto.GenerateTestHash(),
 			BlockHash: crypto.GenerateTestHash(),
 			Status:    Ok,
 		},
@@ -32,7 +32,7 @@ func TestEncodingReceipt(t *testing.T) {
 func TestSanityCheck(t *testing.T) {
 	r := Receipt{
 		data: receiptData{
-			TxID:    crypto.GenerateTestHash(),
+			TxID:      crypto.GenerateTestHash(),
 			BlockHash: crypto.GenerateTestHash(),
 			Status:    Ok,
 		},

--- a/tx/tx_test.go
+++ b/tx/tx_test.go
@@ -111,9 +111,9 @@ func TestTxSanityCheck(t *testing.T) {
 	})
 }
 
-func TestMintbaseTx(t *testing.T) {
+func TestSubsidyTx(t *testing.T) {
 	a, pub, priv := crypto.GenerateTestKeyPair()
-	trx := NewMintbaseTx(crypto.GenerateTestHash(), 111, a, 1111, "mintbase")
+	trx := NewSubsidyTx(crypto.GenerateTestHash(), 111, a, 1111, "subsidy")
 
 	trx.data.Fee = 1
 	assert.Error(t, trx.SanityCheck())
@@ -182,7 +182,7 @@ func TestSendSanityCheck(t *testing.T) {
 	t.Run("Invalid receiver", func(t *testing.T) {
 		trx, priv := GenerateTestSendTx()
 		pld := trx.data.Payload.(*payload.SendPayload)
-		pld.Receiver = crypto.MintbaseAddress
+		pld.Receiver = crypto.TreasuryAddress
 		trx.SetSignature(priv.Sign(trx.SignBytes()))
 		assert.Error(t, trx.SanityCheck())
 	})

--- a/txpool/config.go
+++ b/txpool/config.go
@@ -10,13 +10,13 @@ type Config struct {
 func DefaultConfig() *Config {
 	return &Config{
 		WaitingTimeout: 2 * time.Second,
-		MaxSize:        10000,
+		MaxSize:        2000,
 	}
 }
 
 func TestConfig() *Config {
 	return &Config{
-		WaitingTimeout: 1 * time.Second,
-		MaxSize:        10000,
+		WaitingTimeout: 100 * time.Millisecond,
+		MaxSize:        10,
 	}
 }

--- a/txpool/interface.go
+++ b/txpool/interface.go
@@ -18,8 +18,9 @@ type TxPool interface {
 	TxPoolReader
 
 	SetSandbox(sandbox sandbox.Sandbox)
-	AppendTxs(txs []tx.Tx)
-	AppendTx(tx tx.Tx) error
-	AppendTxAndBroadcast(trx tx.Tx) error
-	RemoveTx(hash crypto.Hash)
+	AppendTxs(txs []*tx.Tx)
+	AppendTx(tx *tx.Tx) error
+	AppendTxAndBroadcast(trx *tx.Tx) error
+	RemoveTx(id crypto.Hash)
+	AllTransactions() []*tx.Tx
 }

--- a/txpool/mock.go
+++ b/txpool/mock.go
@@ -6,30 +6,37 @@ import (
 	"github.com/zarbchain/zarb-go/tx"
 )
 
+var _ TxPool = &MockTxPool{}
+
 // MockTxPool is a testing mock
 type MockTxPool struct {
-	txs map[crypto.Hash]tx.Tx
+	txs []*tx.Tx
 }
 
 func NewMockTxPool() *MockTxPool {
 	return &MockTxPool{
-		txs: make(map[crypto.Hash]tx.Tx),
+		txs: make([]*tx.Tx, 0),
 	}
 }
 func (m *MockTxPool) SetSandbox(sandbox sandbox.Sandbox) {
 
 }
-func (m *MockTxPool) PendingTx(hash crypto.Hash) *tx.Tx {
-	tx, ok := m.txs[hash]
-	if !ok {
-		return nil
+func (m *MockTxPool) PendingTx(id crypto.Hash) *tx.Tx {
+	for _, t := range m.txs {
+		if t.ID().EqualsTo(id) {
+			return t
+		}
 	}
-	return &tx
+	return nil
 }
 
-func (m *MockTxPool) HasTx(hash crypto.Hash) bool {
-	_, has := m.txs[hash]
-	return has
+func (m *MockTxPool) HasTx(id crypto.Hash) bool {
+	for _, t := range m.txs {
+		if t.ID().EqualsTo(id) {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *MockTxPool) Size() int {
@@ -40,18 +47,18 @@ func (m *MockTxPool) Fingerprint() string {
 	return ""
 }
 
-func (m *MockTxPool) AppendTxs(txs []tx.Tx) {
+func (m *MockTxPool) AppendTxs(txs []*tx.Tx) {
 	for _, t := range txs {
-		m.txs[t.ID()] = t
+		m.txs = append(m.txs, t)
 	}
 }
 
-func (m *MockTxPool) AppendTx(tx tx.Tx) error {
-	m.txs[tx.ID()] = tx
+func (m *MockTxPool) AppendTx(t *tx.Tx) error {
+	m.txs = append(m.txs, t)
 	return nil
 }
-func (m *MockTxPool) AppendTxAndBroadcast(trx tx.Tx) error {
-	m.txs[trx.ID()] = trx
+func (m *MockTxPool) AppendTxAndBroadcast(t *tx.Tx) error {
+	m.txs = append(m.txs, t)
 	return nil
 }
 
@@ -59,4 +66,8 @@ func (m *MockTxPool) RemoveTx(hash crypto.Hash) {
 	// This pools is shared between different instances
 	// Lets keep txs then
 	//delete(m.txs, hash)
+}
+
+func (m *MockTxPool) AllTransactions() []*tx.Tx {
+	return m.txs
 }

--- a/txpool/mock.go
+++ b/txpool/mock.go
@@ -48,9 +48,7 @@ func (m *MockTxPool) Fingerprint() string {
 }
 
 func (m *MockTxPool) AppendTxs(txs []*tx.Tx) {
-	for _, t := range txs {
-		m.txs = append(m.txs, t)
-	}
+	m.txs = append(m.txs, txs...)
 }
 
 func (m *MockTxPool) AppendTx(t *tx.Tx) error {

--- a/txpool/pool_test.go
+++ b/txpool/pool_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/zarbchain/zarb-go/account"
+	"github.com/zarbchain/zarb-go/message"
 	"github.com/zarbchain/zarb-go/sandbox"
 
 	"github.com/zarbchain/zarb-go/crypto"
@@ -15,98 +16,97 @@ import (
 	"github.com/zarbchain/zarb-go/logger"
 )
 
-var pool *txPool
-var sb *sandbox.MockSandbox
-var acc1 *account.Account
-var acc1Pub crypto.PublicKey
-var acc1Priv crypto.PrivateKey
+var tPool *txPool
+var tSandbox *sandbox.MockSandbox
+var tAcc1Addr crypto.Address
+var tAcc1Pub crypto.PublicKey
+var tAcc1Priv crypto.PrivateKey
+var tCh chan *message.Message
 
 func setup(t *testing.T) {
 	logger.InitLogger(logger.DefaultConfig())
-	conf := TestConfig()
-	p, _ := NewTxPool(conf, nil)
-	sb = sandbox.NewMockSandbox()
-	addr, pub, priv := crypto.GenerateTestKeyPair()
-	acc1 = account.NewAccount(addr, 0)
+	tCh = make(chan *message.Message, 10)
+	p, _ := NewTxPool(TestConfig(), tCh)
+	tSandbox = sandbox.NewMockSandbox()
+	tAcc1Addr, tAcc1Pub, tAcc1Priv = crypto.GenerateTestKeyPair()
+	acc1 := account.NewAccount(tAcc1Addr, 0)
 	acc1.AddToBalance(10000000000)
-	sb.UpdateAccount(acc1)
-	acc1Priv = priv
-	acc1Pub = pub
-	p.SetSandbox(sb)
-	pool = p.(*txPool)
+	tSandbox.UpdateAccount(acc1)
+	p.SetSandbox(tSandbox)
+	tPool = p.(*txPool)
 }
 
 func TestAppendAndRemove(t *testing.T) {
 	setup(t)
 
 	stamp := crypto.GenerateTestHash()
-	sb.AppendStampAndUpdateHeight(100, stamp)
+	tSandbox.AppendStampAndUpdateHeight(100, stamp)
 
-	trx1 := tx.NewSendTx(stamp, acc1.Sequence()+1, acc1.Address(), acc1.Address(), 1000, 1000, "acc1->acc1: ok", &acc1Pub, nil)
-	trx1.SetSignature(acc1Priv.Sign(trx1.SignBytes()))
-	assert.NoError(t, pool.appendTx(*trx1))
-	assert.Error(t, pool.appendTx(*trx1))
-	pool.RemoveTx(trx1.ID())
-	assert.False(t, pool.HasTx(trx1.ID()))
+	trx1 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAcc1Addr)+1, tAcc1Addr, tAcc1Addr, 1000, 1000, "acc1->acc1: ok", &tAcc1Pub, nil)
+	trx1.SetSignature(tAcc1Priv.Sign(trx1.SignBytes()))
+	assert.NoError(t, tPool.appendTx(trx1))
+	assert.Error(t, tPool.appendTx(trx1))
+	tPool.RemoveTx(trx1.ID())
+	assert.False(t, tPool.HasTx(trx1.ID()))
 }
 
 func TestSendTxValidity(t *testing.T) {
 	setup(t)
 
 	stamp := crypto.GenerateTestHash()
-	senderAddr, senderPub, senderPriv := acc1Pub.Address(), acc1Pub, acc1Priv
+	senderAddr, senderPub, senderPriv := tAcc1Pub.Address(), tAcc1Pub, tAcc1Priv
 	receiverAddr, _, _ := crypto.GenerateTestKeyPair()
 	bigMemo := strings.Repeat("a", 1025)
 
-	sb.AppendStampAndUpdateHeight(100, stamp)
+	tSandbox.AppendStampAndUpdateHeight(100, stamp)
 
-	trx1 := tx.NewSendTx(stamp, acc1.Sequence()+1, senderAddr, receiverAddr, 1000, 1000, bigMemo, &senderPub, nil)
+	trx1 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAcc1Addr)+1, senderAddr, receiverAddr, 1000, 1000, bigMemo, &senderPub, nil)
 	trx1.SetSignature(senderPriv.Sign(trx1.SignBytes()))
-	assert.Error(t, pool.appendTx(*trx1))
+	assert.Error(t, tPool.appendTx(trx1))
 
-	trx2 := tx.NewSendTx(stamp, acc1.Sequence()+1, senderAddr, receiverAddr, 1000, 999, "invalid-fee", &senderPub, nil)
+	trx2 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAcc1Addr)+1, senderAddr, receiverAddr, 1000, 999, "invalid-fee", &senderPub, nil)
 	trx2.SetSignature(senderPriv.Sign(trx2.SignBytes()))
-	assert.Error(t, pool.appendTx(*trx2))
+	assert.Error(t, tPool.appendTx(trx2))
 
-	trx3 := tx.NewSendTx(stamp, acc1.Sequence()+1, senderAddr, receiverAddr, 10000000, 1000, "invalid-fee", &senderPub, nil)
+	trx3 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAcc1Addr)+1, senderAddr, receiverAddr, 10000000, 1000, "invalid-fee", &senderPub, nil)
 	trx3.SetSignature(senderPriv.Sign(trx3.SignBytes()))
-	assert.Error(t, pool.appendTx(*trx3))
+	assert.Error(t, tPool.appendTx(trx3))
 
-	trx4 := tx.NewSendTx(stamp, acc1.Sequence()+1, senderAddr, receiverAddr, 123456789, 123456, "ok", &senderPub, nil)
+	trx4 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAcc1Addr)+1, senderAddr, receiverAddr, 123456789, 123456, "ok", &senderPub, nil)
 	trx4.SetSignature(senderPriv.Sign(trx4.SignBytes()))
-	assert.NoError(t, pool.appendTx(*trx4))
+	assert.NoError(t, tPool.appendTx(trx4))
 
-	trx5 := tx.NewSendTx(stamp, acc1.Sequence()+1, senderAddr, receiverAddr, 123456000, 123456, "ok", &senderPub, nil)
+	trx5 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAcc1Addr)+1, senderAddr, receiverAddr, 123456000, 123456, "ok", &senderPub, nil)
 	trx5.SetSignature(senderPriv.Sign(trx5.SignBytes()))
-	assert.NoError(t, pool.appendTx(*trx5))
+	assert.NoError(t, tPool.appendTx(trx5))
 
-	trx6 := tx.NewSendTx(stamp, acc1.Sequence()+1, senderAddr, receiverAddr, 1, 1000, "ok", &senderPub, nil)
+	trx6 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAcc1Addr)+1, senderAddr, receiverAddr, 1, 1000, "ok", &senderPub, nil)
 	trx6.SetSignature(senderPriv.Sign(trx6.SignBytes()))
-	assert.NoError(t, pool.appendTx(*trx6))
+	assert.NoError(t, tPool.appendTx(trx6))
 
-	trx7 := tx.NewSendTx(stamp, acc1.Sequence()+1, senderAddr, receiverAddr, 1000, 1000, "ok", &senderPub, nil)
+	trx7 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAcc1Addr)+1, senderAddr, receiverAddr, 1000, 1000, "ok", &senderPub, nil)
 	trx7.SetSignature(senderPriv.Sign(trx7.SignBytes()))
-	assert.NoError(t, pool.appendTx(*trx7))
+	assert.NoError(t, tPool.appendTx(trx7))
 
-	trx8 := tx.NewSendTx(stamp, acc1.Sequence()+1, senderAddr, receiverAddr, 1000000, 1000, "ok", &senderPub, nil)
+	trx8 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAcc1Addr)+1, senderAddr, receiverAddr, 1000000, 1000, "ok", &senderPub, nil)
 	trx8.SetSignature(senderPriv.Sign(trx8.SignBytes()))
-	assert.NoError(t, pool.appendTx(*trx8))
+	assert.NoError(t, tPool.appendTx(trx8))
 
-	trx9 := tx.NewSendTx(stamp, acc1.Sequence()+1, senderAddr, receiverAddr, 10000000, 10000, "ok", &senderPub, nil)
+	trx9 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAcc1Addr)+1, senderAddr, receiverAddr, 10000000, 10000, "ok", &senderPub, nil)
 	trx9.SetSignature(senderPriv.Sign(trx9.SignBytes()))
-	assert.NoError(t, pool.appendTx(*trx9))
+	assert.NoError(t, tPool.appendTx(trx9))
 
-	trx10 := tx.NewSendTx(stamp, acc1.Sequence()+2, senderAddr, receiverAddr, 10000000, 10000, "invalid-sequence", &senderPub, nil)
+	trx10 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAcc1Addr)+2, senderAddr, receiverAddr, 10000000, 10000, "invalid-sequence", &senderPub, nil)
 	trx10.SetSignature(senderPriv.Sign(trx10.SignBytes()))
-	assert.Error(t, pool.appendTx(*trx10))
+	assert.Error(t, tPool.appendTx(trx10))
 
-	trx11 := tx.NewSendTx(stamp, acc1.Sequence()+1, senderAddr, receiverAddr, -10000000, 10000, "negative-amount", &senderPub, nil)
+	trx11 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAcc1Addr)+1, senderAddr, receiverAddr, -10000000, 10000, "negative-amount", &senderPub, nil)
 	trx11.SetSignature(senderPriv.Sign(trx11.SignBytes()))
-	assert.Error(t, pool.appendTx(*trx11))
+	assert.Error(t, tPool.appendTx(trx11))
 
-	trx12 := tx.NewSendTx(stamp, acc1.Sequence()+1, senderAddr, receiverAddr, 10000000, -10000, "negative-fee", &senderPub, nil)
+	trx12 := tx.NewSendTx(stamp, tSandbox.AccSeq(tAcc1Addr)+1, senderAddr, receiverAddr, 10000000, -10000, "negative-fee", &senderPub, nil)
 	trx12.SetSignature(senderPriv.Sign(trx12.SignBytes()))
-	assert.Error(t, pool.appendTx(*trx12))
+	assert.Error(t, tPool.appendTx(trx12))
 }
 
 func TestStampValidity(t *testing.T) {
@@ -117,25 +117,81 @@ func TestStampValidity(t *testing.T) {
 	stamp3 := crypto.GenerateTestHash()
 	stamp4 := crypto.GenerateTestHash()
 	stamp5 := crypto.GenerateTestHash()
-	senderAddr, senderPub, senderPriv := acc1Pub.Address(), acc1Pub, acc1Priv
+	senderAddr, senderPub, senderPriv := tAcc1Pub.Address(), tAcc1Pub, tAcc1Priv
 	receiverAddr, _, _ := crypto.GenerateTestKeyPair()
 
-	sb.AppendStampAndUpdateHeight(100, stamp1)
-	sb.AppendStampAndUpdateHeight(101, stamp2)
-	sb.AppendStampAndUpdateHeight(102, stamp3)
-	sb.AppendStampAndUpdateHeight(103, stamp4)
+	tSandbox.AppendStampAndUpdateHeight(100, stamp1)
+	tSandbox.AppendStampAndUpdateHeight(101, stamp2)
+	tSandbox.AppendStampAndUpdateHeight(102, stamp3)
+	tSandbox.AppendStampAndUpdateHeight(103, stamp4)
 
-	trx1 := tx.NewSendTx(stamp1, acc1.Sequence()+1, senderAddr, receiverAddr, 1000, 1000, "stamp1-ok", &senderPub, nil)
+	trx1 := tx.NewSendTx(stamp1, tSandbox.AccSeq(tAcc1Addr)+1, senderAddr, receiverAddr, 1000, 1000, "stamp1-ok", &senderPub, nil)
 	trx1.SetSignature(senderPriv.Sign(trx1.SignBytes()))
-	assert.NoError(t, pool.appendTx(*trx1))
+	assert.NoError(t, tPool.appendTx(trx1))
 
-	sb.AppendStampAndUpdateHeight(104, stamp5)
+	tSandbox.AppendStampAndUpdateHeight(104, stamp5)
 
-	trx2 := tx.NewSendTx(stamp1, acc1.Sequence()+1, senderAddr, receiverAddr, 1000, 1000, "stamp1-invalid", &senderPub, nil)
+	trx2 := tx.NewSendTx(stamp1, tSandbox.AccSeq(tAcc1Addr)+1, senderAddr, receiverAddr, 1000, 1000, "stamp1-invalid", &senderPub, nil)
 	trx2.SetSignature(senderPriv.Sign(trx2.SignBytes()))
-	assert.Error(t, pool.appendTx(*trx2))
+	assert.Error(t, tPool.appendTx(trx2))
 
-	trx3 := tx.NewSendTx(stamp2, acc1.Sequence()+1, senderAddr, receiverAddr, 1000, 1000, "stamp2-ok", &senderPub, nil)
+	trx3 := tx.NewSendTx(stamp2, tSandbox.AccSeq(tAcc1Addr)+1, senderAddr, receiverAddr, 1000, 1000, "stamp2-ok", &senderPub, nil)
 	trx3.SetSignature(senderPriv.Sign(trx3.SignBytes()))
-	assert.NoError(t, pool.appendTx(*trx3))
+	assert.NoError(t, tPool.appendTx(trx3))
+}
+
+func TestPending(t *testing.T) {
+	setup(t)
+
+	a, _, _ := crypto.GenerateTestKeyPair()
+	stamp := crypto.GenerateTestHash()
+	tSandbox.AppendStampAndUpdateHeight(100, stamp)
+	trx := tx.NewSendTx(stamp, tSandbox.AccSeq(tAcc1Addr)+1, tAcc1Pub.Address(), a, 1000, 1000, "stamp1-ok", &tAcc1Pub, nil)
+	trx.SetSignature(tAcc1Priv.Sign(trx.SignBytes()))
+
+	go func() {
+		for {
+			msg := <-tCh
+			pld := msg.Payload.(*message.TxsReqPayload)
+			if pld.IDs[0].EqualsTo(trx.ID()) {
+				assert.NoError(t, tPool.AppendTx(trx))
+			}
+		}
+	}()
+
+	assert.NotNil(t, tPool.PendingTx(trx.ID()))
+
+	invID := crypto.GenerateTestHash()
+	assert.Nil(t, tPool.PendingTx(invID))
+}
+
+func TestGetAllTransaction(t *testing.T) {
+	setup(t)
+
+	go func() {
+		for {
+			<-tPool.appendTxCh
+		}
+	}()
+	trxs0 := tPool.AllTransactions()
+	assert.Empty(t, trxs0)
+
+	stamp := crypto.GenerateTestHash()
+	tSandbox.AppendStampAndUpdateHeight(100, stamp)
+	trxs1 := make([]*tx.Tx, 10)
+	for i := 0; i < len(trxs1); i++ {
+		a, _, _ := crypto.GenerateTestKeyPair()
+		trx := tx.NewSendTx(stamp, tSandbox.AccSeq(tAcc1Addr)+1, tAcc1Pub.Address(), a, 1000, 1000, "stamp1-ok", &tAcc1Pub, nil)
+		trx.SetSignature(tAcc1Priv.Sign(trx.SignBytes()))
+		assert.NoError(t, tPool.AppendTx(trx))
+		trxs1[i] = trx
+	}
+
+	trxs2 := tPool.AllTransactions()
+	for i := 0; i < 10; i++ {
+		// Should be in same order
+		assert.Equal(t, trxs1[i].ID(), trxs2[i].ID())
+	}
+
+	assert.Equal(t, tPool.Size(), 10)
 }

--- a/www/capnp/block.go
+++ b/www/capnp/block.go
@@ -98,7 +98,7 @@ func (f factory) ToVerboseBlock(block *block.Block, res *BlockResult) error {
 		return err
 	}
 	// Transactions
-	cTxIDs, _ := ctxs.NewHashes(int32(block.TxIDs().Count()))
+	cTxIDs, _ := ctxs.NewHashes(int32(block.TxIDs().Len()))
 	for i, hash := range block.TxIDs().IDs() {
 		if err := cTxIDs.Set(i, hash.RawBytes()); err != nil {
 			return err


### PR DESCRIPTION
- Get all transaction from txpool for proposing a block
- Resetting sandbox before proposing a block
- Add test for send-to-self transaction
- Add prepend-tx method
-  New param: MaximumTransactionPerBlock
- Add accumulated-fee to mintbase tx