### PR TITLE
add SemVersion Support via Git Tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PACKAGES=$(shell go list ./... | grep -v 'tests')
 TAGS=-tags 'zarb'
 HERUMI= $(shell pwd)/.herumi
 CGO_LDFLAGS=CGO_LDFLAGS="-L$(HERUMI)/bls/lib -lbls384_256 -lm -lstdc++"
-LDFLAGS= -ldflags "-X github.com/zarbchain/zarb-go/version.GitCommit=`git rev-parse --short=8 HEAD`"
+LDFLAGS= -ldflags "-X github.com/zarbchain/zarb-go/version.GitCommit=`git rev-parse --short=8 HEAD` -X github.com/zarbchain/zarb-go/version.SemVersion=`git describe --tags --abbrev=0`"
 CAPNP_INC = -I$(GOPATH)/src/zombiezen.com/go/capnproto2/std
 PROTO_INC = -I. -I$(GOPATH)/src/github.com/googleapis/googleapis
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/btcsuite/btcd v0.21.0-beta // indirect
 	github.com/btcsuite/btcutil v1.0.3-0.20201201144236-d63d9f2b44dd
+	github.com/coreos/go-semver v0.3.0
 	github.com/davidlazar/go-crypto v0.0.0-20190912175916-7055855a373f // indirect
 	github.com/dchest/blake2b v1.0.0
 	github.com/fxamacker/cbor/v2 v2.2.0

--- a/version/version.go
+++ b/version/version.go
@@ -2,19 +2,30 @@ package version
 
 import (
 	"fmt"
+
+	"github.com/coreos/go-semver/semver"
 )
 
 var (
-	NodeVersion Version
-	GitCommit   string
-)
-
-func init() {
-	NodeVersion = Version{
+	NodeVersion Version = Version{
 		Major: 1,
 		Minor: 0,
 		Patch: 0,
 	}
+	SemVersion string = "1.0.0-beta"
+	GitCommit  string
+)
+
+func init() {
+	sv, err := semver.NewVersion(SemVersion)
+	if err == nil {
+		NodeVersion = Version{
+			Major: int(sv.Major),
+			Minor: int(sv.Minor),
+			Patch: int(sv.Patch),
+		}
+	}
+
 }
 
 type Version struct {


### PR DESCRIPTION
- Tagged as V1.0.1
- `git tag 1.0.1` will update version automaticly
- ```-ldflags "-X github.com/zarbchain/zarb-go/version.GitCommit=`git rev-parse --short=8 HEAD`"``` flag added to make file