### PR TITLE
p2p: Add responseTarget to Aleyk message

### DIFF
--- a/network/mock.go
+++ b/network/mock.go
@@ -37,15 +37,18 @@ func (mock *MockNetwork) LeaveDownloadTopic() {}
 func (mock *MockNetwork) SelfID() peer.ID {
 	return mock.id
 }
-func (mock *MockNetwork) ReceivingMessageFromOtherPeer(id peer.ID, pld payload.Payload) {
-	msg := message.NewMessage(id, pld)
+func (mock *MockNetwork) ReceivingMessageFromOtherPeer(initiator peer.ID, pld payload.Payload) {
+	msg := message.NewMessage(initiator, pld)
 	d, _ := msg.Encode()
 	if d != nil {
 		logger.Info("Parsing the message", "msg", msg)
-		mock.CallbackFn(d, id)
+		mock.CallbackFn(d, initiator)
 	}
 }
 func (mock *MockNetwork) PublishMessage(msg *message.Message) error {
+	if err := msg.SanityCheck(); err != nil {
+		return err
+	}
 	mock.BroadcastCh <- msg
 	return nil
 }

--- a/sync/handler_aleyk.go
+++ b/sync/handler_aleyk.go
@@ -23,19 +23,23 @@ func (handler *aleykHandler) ParsPayload(p payload.Payload, initiator peer.ID) e
 	handler.logger.Trace("Parsing Aleyk payload", "pld", pld)
 
 	peer := handler.peerSet.MustGetPeer(initiator)
-	if pld.ResponseCode != payload.ResponseCodeOK {
-		handler.logger.Warn("Our Salam is not welcomed!", "message", pld.ResponseMessage, "peer", util.FingerprintPeerID(initiator))
-		peer.UpdateStatus(peerset.StatusCodeBanned)
-	} else {
-		peer.UpdateStatus(peerset.StatusCodeOK)
-		peer.UpdateMoniker(pld.Moniker)
-		peer.UpdateHeight(pld.Height)
-		peer.UpdateNodeVersion(pld.NodeVersion)
-		peer.UpdatePublicKey(pld.PublicKey)
-		peer.UpdateInitialBlockDownload(util.IsFlagSet(pld.Flags, FlagInitialBlockDownload))
 
-		handler.peerSet.UpdateMaxClaimedHeight(pld.Height)
+	if pld.ResponseTarget == handler.SelfID() {
+		if pld.ResponseCode == payload.ResponseCodeOK {
+			peer.UpdateStatus(peerset.StatusCodeOK)
+		} else {
+			handler.logger.Warn("Our Salam is not welcomed!", "message", pld.ResponseMessage, "peer", util.FingerprintPeerID(initiator))
+			peer.UpdateStatus(peerset.StatusCodeBanned)
+		}
 	}
+
+	peer.UpdateMoniker(pld.Moniker)
+	peer.UpdateHeight(pld.Height)
+	peer.UpdateNodeVersion(pld.NodeVersion)
+	peer.UpdatePublicKey(pld.PublicKey)
+	peer.UpdateInitialBlockDownload(util.IsFlagSet(pld.Flags, FlagInitialBlockDownload))
+
+	handler.peerSet.UpdateMaxClaimedHeight(pld.Height)
 
 	return nil
 }

--- a/sync/handler_aleyk_test.go
+++ b/sync/handler_aleyk_test.go
@@ -6,36 +6,55 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/zarbchain/zarb-go/crypto"
 	"github.com/zarbchain/zarb-go/sync/message/payload"
+	"github.com/zarbchain/zarb-go/sync/peerset"
 	"github.com/zarbchain/zarb-go/util"
 )
 
 func TestParsingAleykMessages(t *testing.T) {
 	setup(t)
 
-	t.Run("Alice receives Aleyk message from a peer. The peer is behind alice. Alice should not request for blocks", func(t *testing.T) {
+	t.Run("Alice receives Aleyk message a Peer.", func(t *testing.T) {
 		_, pub, _ := crypto.GenerateTestKeyPair()
-		pld := payload.NewAleykPayload(payload.ResponseCodeOK, "Welcome!", "kitty", pub, 1, 0)
-		tAliceNet.ReceivingMessageFromOtherPeer(util.RandomPeerID(), pld)
+		pid := util.RandomPeerID()
+		pld := payload.NewAleykPayload(tAlicePeerID, payload.ResponseCodeOK, "Welcome", "kitty", pub, 1, 0)
+		tAliceNet.ReceivingMessageFromOtherPeer(pid, pld)
 
-		shouldNotPublishPayloadWithThisType(t, tAliceNet, payload.PayloadTypeLatestBlocksRequest)
+		peer := tAliceSync.peerSet.GetPeer(pid)
+		assert.Equal(t, peer.Status(), peerset.StatusCodeOK)
 	})
 
-	t.Run("Alice receives Aleyk message from a peer. The peer is ahead of alice. Alice should request for new blocks", func(t *testing.T) {
+	t.Run("Alice receives not welcoming Aleyk message from a peer", func(t *testing.T) {
 		_, pub, _ := crypto.GenerateTestKeyPair()
+		pid := util.RandomPeerID()
 		claimedHeight := tAliceState.LastBlockHeight() + 5
-		pld := payload.NewAleykPayload(payload.ResponseCodeOK, "Welcome!", "kitty", pub, claimedHeight, 0)
-		tAliceNet.ReceivingMessageFromOtherPeer(util.RandomPeerID(), pld)
+		pld := payload.NewAleykPayload(tAlicePeerID, payload.ResponseCodeRejected, "Not Welcome!", "kitty", pub, claimedHeight, 0)
+		tAliceNet.ReceivingMessageFromOtherPeer(pid, pld)
 
-		shouldPublishPayloadWithThisType(t, tAliceNet, payload.PayloadTypeLatestBlocksRequest)
-		assert.Equal(t, tAliceSync.peerSet.MaxClaimedHeight(), claimedHeight)
+		peer := tAliceSync.peerSet.GetPeer(pid)
+		assert.Equal(t, peer.Status(), peerset.StatusCodeBanned)
 	})
 
-	t.Run("Alice receives Aleyk message from a peer. The peer is at the same height with alice. Alice should not request for blocks", func(t *testing.T) {
+	t.Run("Alice receives Aleyk message from a peer but not targeted Alice", func(t *testing.T) {
 		_, pub, _ := crypto.GenerateTestKeyPair()
-		claimedHeight := tAliceState.LastBlockHeight()
-		pld := payload.NewAleykPayload(payload.ResponseCodeOK, "Welcome!", "kitty", pub, claimedHeight, 0)
-		tAliceNet.ReceivingMessageFromOtherPeer(util.RandomPeerID(), pld)
+		pid := util.RandomPeerID()
+		claimedHeight := tAliceState.LastBlockHeight() + 5
+		pld := payload.NewAleykPayload(util.RandomPeerID(), payload.ResponseCodeOK, "Welcome", "kitty", pub, claimedHeight, 0)
+		tAliceNet.ReceivingMessageFromOtherPeer(pid, pld)
 
-		shouldNotPublishPayloadWithThisType(t, tAliceNet, payload.PayloadTypeLatestBlocksRequest)
+		peer := tAliceSync.peerSet.GetPeer(pid)
+		assert.Equal(t, peer.Status(), peerset.StatusCodeUnknown)
 	})
+
+	t.Run("Alice eavesdrops Aleyk messages", func(t *testing.T) {
+		_, pub, _ := crypto.GenerateTestKeyPair()
+		pid := util.RandomPeerID()
+		claimedHeight := tAliceState.LastBlockHeight() + 5
+		pld := payload.NewAleykPayload(util.RandomPeerID(), payload.ResponseCodeRejected, "Not Welcome!", "kitty", pub, claimedHeight, 0)
+		tAliceNet.ReceivingMessageFromOtherPeer(pid, pld)
+
+		peer := tAliceSync.peerSet.GetPeer(pid)
+		assert.Equal(t, peer.Status(), peerset.StatusCodeUnknown)
+		assert.Equal(t, peer.PublicKey().String(), pub.String())
+	})
+
 }

--- a/sync/handler_salam.go
+++ b/sync/handler_salam.go
@@ -28,7 +28,7 @@ func (handler *salamHandler) ParsPayload(p payload.Payload, initiator peer.ID) e
 		handler.logger.Info("Received a message from different chain", "genesis_hash", pld.GenesisHash, "peer", util.FingerprintPeerID(initiator))
 		// Response to salam
 		peer.UpdateStatus(peerset.StatusCodeBanned)
-		handler.broadcastAleyk(payload.ResponseCodeRejected, "Invalid genesis hash")
+		handler.broadcastAleyk(initiator, payload.ResponseCodeRejected, "Invalid genesis hash")
 		return nil
 	}
 
@@ -42,7 +42,7 @@ func (handler *salamHandler) ParsPayload(p payload.Payload, initiator peer.ID) e
 	handler.peerSet.UpdateMaxClaimedHeight(pld.Height)
 
 	// Response to salam
-	handler.broadcastAleyk(payload.ResponseCodeOK, "Welcome!")
+	handler.broadcastAleyk(initiator, payload.ResponseCodeOK, "Welcome!")
 
 	return nil
 }

--- a/sync/handler_salam_test.go
+++ b/sync/handler_salam_test.go
@@ -46,4 +46,15 @@ func TestParsingSalamMessages(t *testing.T) {
 		assert.Equal(t, p.Height(), 3)
 		assert.Equal(t, p.InitialBlockDownload(), true)
 	})
+
+	t.Run("Alice receives Salam message from a peer. Peer is ahead. Alice should request for blocks", func(t *testing.T) {
+		_, pub, _ := crypto.GenerateTestKeyPair()
+		claimedHeight := tAliceState.LastBlockHeight() + 5
+		pld := payload.NewSalamPayload("kitty", pub, tAliceState.GenHash, claimedHeight, 0)
+		tAliceNet.ReceivingMessageFromOtherPeer(util.RandomPeerID(), pld)
+
+		shouldPublishPayloadWithThisTypeAndResponseCode(t, tAliceNet, payload.PayloadTypeAleyk, payload.ResponseCodeOK)
+		shouldPublishPayloadWithThisType(t, tAliceNet, payload.PayloadTypeLatestBlocksRequest)
+		assert.Equal(t, tAliceSync.peerSet.MaxClaimedHeight(), claimedHeight)
+	})
 }

--- a/sync/handler_salam_test.go
+++ b/sync/handler_salam_test.go
@@ -46,15 +46,4 @@ func TestParsingSalamMessages(t *testing.T) {
 		assert.Equal(t, p.Height(), 3)
 		assert.Equal(t, p.InitialBlockDownload(), true)
 	})
-
-	t.Run("Alice receives Salam message from a peer. Peer is ahead. Alice should request for blocks", func(t *testing.T) {
-		_, pub, _ := crypto.GenerateTestKeyPair()
-		claimedHeight := tAliceState.LastBlockHeight() + 5
-		pld := payload.NewSalamPayload("kitty", pub, tAliceState.GenHash, claimedHeight, 0)
-		tAliceNet.ReceivingMessageFromOtherPeer(util.RandomPeerID(), pld)
-
-		shouldPublishPayloadWithThisTypeAndResponseCode(t, tAliceNet, payload.PayloadTypeAleyk, payload.ResponseCodeOK)
-		shouldPublishPayloadWithThisType(t, tAliceNet, payload.PayloadTypeLatestBlocksRequest)
-		assert.Equal(t, tAliceSync.peerSet.MaxClaimedHeight(), claimedHeight)
-	})
 }

--- a/sync/message/messages.go
+++ b/sync/message/messages.go
@@ -21,11 +21,11 @@ type Message struct {
 	Payload   payload.Payload
 }
 
-func NewMessage(id peer.ID, pld payload.Payload) *Message {
+func NewMessage(initiator peer.ID, pld payload.Payload) *Message {
 	return &Message{
 		Version:   LastVersion,
 		Flags:     0,
-		Initiator: id,
+		Initiator: initiator,
 		Payload:   pld,
 	}
 }

--- a/sync/message/payload/aleyk.go
+++ b/sync/message/payload/aleyk.go
@@ -3,24 +3,27 @@ package payload
 import (
 	"fmt"
 
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/zarbchain/zarb-go/crypto"
 	"github.com/zarbchain/zarb-go/errors"
 	"github.com/zarbchain/zarb-go/version"
 )
 
 type AleykPayload struct {
-	ResponseCode    ResponseCode     `cbor:"1,keyasint"`
-	ResponseMessage string           `cbor:"2,keyasint"`
-	NodeVersion     string           `cbor:"3,keyasint"`
-	Moniker         string           `cbor:"4,keyasint"`
-	PublicKey       crypto.PublicKey `cbor:"5,keyasint"`
-	Height          int              `cbor:"6,keyasint"`
-	Flags           int              `cbor:"7,keyasint"`
+	ResponseTarget  peer.ID          `cbor:"1,keyasint"`
+	ResponseCode    ResponseCode     `cbor:"2,keyasint"`
+	ResponseMessage string           `cbor:"3,keyasint"`
+	NodeVersion     string           `cbor:"4,keyasint"`
+	Moniker         string           `cbor:"5,keyasint"`
+	PublicKey       crypto.PublicKey `cbor:"6,keyasint"`
+	Height          int              `cbor:"7,keyasint"`
+	Flags           int              `cbor:"8,keyasint"`
 }
 
-func NewAleykPayload(code ResponseCode, msg string, moniker string,
+func NewAleykPayload(target peer.ID, code ResponseCode, msg string, moniker string,
 	pub crypto.PublicKey, height int, flags int) Payload {
 	return &AleykPayload{
+		ResponseTarget:  target,
 		ResponseCode:    code,
 		ResponseMessage: msg,
 		NodeVersion:     version.Version(),
@@ -32,6 +35,9 @@ func NewAleykPayload(code ResponseCode, msg string, moniker string,
 }
 
 func (p *AleykPayload) SanityCheck() error {
+	if err := p.ResponseTarget.Validate(); err != nil {
+		return err
+	}
 	if p.Height < 0 {
 		return errors.Errorf(errors.ErrInvalidMessage, "invalid Height")
 	}

--- a/sync/message/payload/aleyk_test.go
+++ b/sync/message/payload/aleyk_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/zarbchain/zarb-go/crypto"
+	"github.com/zarbchain/zarb-go/util"
 )
 
 func TestAleykType(t *testing.T) {
@@ -13,8 +14,24 @@ func TestAleykType(t *testing.T) {
 }
 
 func TestAleykPayload(t *testing.T) {
-	p := NewAleykPayload(ResponseCodeRejected, "busy",
-		"devil", crypto.GenerateTestSigner().PublicKey(), -1, 0)
+	t.Run("Invalid target", func(t *testing.T) {
+		p := NewAleykPayload("bad", ResponseCodeRejected, "busy",
+			"devil", crypto.GenerateTestSigner().PublicKey(), -1, 0)
 
-	assert.Error(t, p.SanityCheck())
+		assert.Error(t, p.SanityCheck())
+	})
+
+	t.Run("Invalid height", func(t *testing.T) {
+		p := NewAleykPayload(util.RandomPeerID(), ResponseCodeRejected, "busy",
+			"devil", crypto.GenerateTestSigner().PublicKey(), -1, 0)
+
+		assert.Error(t, p.SanityCheck())
+	})
+
+	t.Run("Ok", func(t *testing.T) {
+		p := NewAleykPayload(util.RandomPeerID(), ResponseCodeRejected, "busy",
+			"devil", crypto.GenerateTestSigner().PublicKey(), 100, 0)
+
+		assert.NoError(t, p.SanityCheck())
+	})
 }

--- a/sync/peerset/peer.go
+++ b/sync/peerset/peer.go
@@ -44,7 +44,7 @@ type peerData struct {
 	Moniker              string
 	NodeVersion          string
 	PeerID               peer.ID
-	Address              crypto.Address
+	Address              *crypto.Address
 	PublicKey            crypto.PublicKey
 	InitialBlockDownload bool
 	Height               int
@@ -163,8 +163,12 @@ func (p *Peer) UpdatePublicKey(pub crypto.PublicKey) {
 	p.lk.Lock()
 	defer p.lk.Unlock()
 
-	p.data.PublicKey = pub
-	p.data.Address = pub.Address()
+	// TODO: write test for me
+	if err := pub.SanityCheck(); err == nil {
+		addr := pub.Address()
+		p.data.PublicKey = pub
+		p.data.Address = &addr
+	}
 }
 
 func (p *Peer) UpdateHeight(height int) {

--- a/sync/peerset/session.go
+++ b/sync/peerset/session.go
@@ -40,6 +40,13 @@ func (s *Session) SetLastResponseCode(code payload.ResponseCode) {
 	s.data.LastActivityAt = util.Now()
 }
 
+func (s *Session) PeerID() peer.ID {
+	s.lk.RLock()
+	defer s.lk.RUnlock()
+
+	return s.data.PeerID
+}
+
 func (s *Session) SessionID() int {
 	s.lk.RLock()
 	defer s.lk.RUnlock()

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -187,12 +187,13 @@ func (sync *synchronizer) broadcastSalam() {
 	sync.broadcast(pld)
 }
 
-func (sync *synchronizer) broadcastAleyk(code payload.ResponseCode, resMsg string) {
+func (sync *synchronizer) broadcastAleyk(target peer.ID, code payload.ResponseCode, resMsg string) {
 	flags := 0
 	if sync.config.InitialBlockDownload {
 		flags = util.SetFlag(flags, FlagInitialBlockDownload)
 	}
 	response := payload.NewAleykPayload(
+		target,
 		code,
 		resMsg,
 		sync.config.Moniker,

--- a/www/http/blockchain.go
+++ b/www/http/blockchain.go
@@ -61,7 +61,6 @@ func (s *Server) NetworkHandler(w http.ResponseWriter, r *http.Request) {
 		peer.UpdateMoniker(moniker)
 		peer.UpdateNodeVersion(ver)
 		peer.UpdateMoniker(moniker)
-		peer.UpdatePublicKey(pub)
 		peer.UpdateInitialBlockDownload(p.InitialBlockDownload())
 		peer.UpdateHeight(int(p.Height()))
 		peer.UpdateInvalidMessage(int(p.InvalidMessages()))


### PR DESCRIPTION
Target Peer ID is added to Alyek messages. Other peers can eavesdrop the message to update the peer information.