### PR TITLE
Test: Strengthening a test for consensus in slow environments

### DIFF
--- a/consensus/prepare_test.go
+++ b/consensus/prepare_test.go
@@ -69,7 +69,7 @@ func TestByzantineVote1(t *testing.T) {
 	// =================================
 	// Np votes
 	testAddVote(tConsP, vote.VoteTypeChangeProposer, h, r, crypto.UndefHash, tIndexB) // Byzantine vote
-
+	shouldPublishVote(t, tConsP, vote.VoteTypeChangeProposer, crypto.UndefHash)
 	// Np is unable to progress
 
 	// =================================


### PR DESCRIPTION
## Description

The `TestByzantineVote1` failed in slow containers like MacOS github action rarely.
This PR straightens this test  

## Checklist
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: -->
- [X] My code follows the code style of this project.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
