### PR TITLE
Set round to zero on constructing consensus

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -61,8 +61,8 @@ func NewConsensus(
 	cs.commitState = &commitState{cs}
 	cs.changeProposerState = &changeProposerState{cs}
 
-	cs.height = -1
-	cs.round = -1
+	cs.height = 0
+	cs.round = 0
 
 	return cs, nil
 }

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -422,6 +422,8 @@ func TestConsensusInvalidVote(t *testing.T) {
 func TestPickRandomVote(t *testing.T) {
 	setup(t)
 
+	assert.Nil(t, tConsP.PickRandomVote())
+
 	testEnterNewHeight(tConsP)
 	assert.Nil(t, tConsP.PickRandomVote())
 


### PR DESCRIPTION
## Description

There is a random panic on starting the node. It is caused by picking a random vote. Since the round is set to `-1`, then `round+1` is zero, the random function sets the max to `MaxInt16`. By this change the round set to zero then the random vote will be picked between zero and one, which ultimately is a nil vote.


## Checklist
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] CHANGELOG is updated.
