### PR TITLE
Removing FingerprintPeerID from utils

### DIFF
--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -127,7 +127,7 @@ func shouldPublishBlockAnnounce(t *testing.T, cons *consensus, hash hash.Hash) {
 			require.NoError(t, fmt.Errorf("Timeout"))
 			return
 		case msg := <-cons.broadcastCh:
-			logger.Info("shouldPublishBlockAnnounce", "msg", msg)
+			logger.Info("shouldPublishBlockAnnounce", "message", msg)
 
 			if msg.Type() == message.MessageTypeBlockAnnounce {
 				m := msg.(*message.BlockAnnounceMessage)
@@ -147,7 +147,7 @@ func shouldPublishProposal(t *testing.T, cons *consensus, height int32, round in
 			require.NoError(t, fmt.Errorf("Timeout"))
 			return
 		case msg := <-cons.broadcastCh:
-			logger.Info("shouldPublishProposal", "msg", msg)
+			logger.Info("shouldPublishProposal", "message", msg)
 
 			if msg.Type() == message.MessageTypeProposal {
 				m := msg.(*message.ProposalMessage)
@@ -168,7 +168,7 @@ func shouldPublishQueryProposal(t *testing.T, cons *consensus, height int32, rou
 			require.NoError(t, fmt.Errorf("Timeout"))
 			return
 		case msg := <-cons.broadcastCh:
-			logger.Info("shouldPublishQueryProposal", "msg", msg)
+			logger.Info("shouldPublishQueryProposal", "message", msg)
 
 			if msg.Type() == message.MessageTypeQueryProposal {
 				m := msg.(*message.QueryProposalMessage)
@@ -188,7 +188,7 @@ func shouldPublishVote(t *testing.T, cons *consensus, voteType vote.Type, hash h
 		case <-timeout.C:
 			require.NoError(t, fmt.Errorf("Timeout"))
 		case msg := <-cons.broadcastCh:
-			logger.Info("shouldPublishVote", "msg", msg)
+			logger.Info("shouldPublishVote", "message", msg)
 
 			if msg.Type() == message.MessageTypeVote {
 				m := msg.(*message.VoteMessage)

--- a/network/gossip.go
+++ b/network/gossip.go
@@ -8,7 +8,6 @@ import (
 	lp2pps "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/zarbchain/zarb-go/errors"
 	"github.com/zarbchain/zarb-go/logger"
-	"github.com/zarbchain/zarb-go/util"
 )
 
 type gossipService struct {
@@ -92,7 +91,7 @@ func (g *gossipService) onReceiveMessage(m *lp2pps.Message) {
 		return
 	}
 
-	g.logger.Debug("receiving new gossip message", "from", util.FingerprintPeerID(m.GetFrom()), "received from", util.FingerprintPeerID(m.ReceivedFrom))
+	g.logger.Debug("receiving new gossip message", "from", m.GetFrom(), "received from", m.ReceivedFrom)
 	event := &GossipMessage{
 		Source: m.GetFrom(),
 		From:   m.ReceivedFrom,

--- a/network/mock.go
+++ b/network/mock.go
@@ -6,6 +6,7 @@ import (
 
 	lp2pcore "github.com/libp2p/go-libp2p-core"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/zarbchain/zarb-go/util"
 )
 
 var _ Network = &MockNetwork{}
@@ -103,4 +104,12 @@ func (mock *MockNetwork) NumConnectedPeers() int {
 }
 func (mock *MockNetwork) AddAnotherNetwork(net *MockNetwork) {
 	mock.OtherNets = append(mock.OtherNets, net)
+}
+
+/// TestRandomPeerID returns a random peer ID
+func TestRandomPeerID() peer.ID {
+	s := util.Uint64ToSlice(util.RandUint64(0))
+	id := [34]byte{0x12, 32}
+	copy(id[2:], s[:])
+	return peer.ID(id[:])
 }

--- a/network/network.go
+++ b/network/network.go
@@ -219,7 +219,7 @@ func (n *network) TopicName(topic string) string {
 
 func (n *network) CloseConnection(pid lp2peer.ID) {
 	if err := n.host.Network().ClosePeer(pid); err != nil {
-		n.logger.Warn("unable to close connection", "peer", util.FingerprintPeerID(pid))
+		n.logger.Warn("unable to close connection", "peer", pid)
 	}
 }
 

--- a/network/stream.go
+++ b/network/stream.go
@@ -9,7 +9,6 @@ import (
 	lp2peer "github.com/libp2p/go-libp2p-core/peer"
 	"github.com/zarbchain/zarb-go/errors"
 	"github.com/zarbchain/zarb-go/logger"
-	"github.com/zarbchain/zarb-go/util"
 )
 
 type streamService struct {
@@ -42,7 +41,7 @@ func (s *streamService) Stop() {
 func (s *streamService) handleStream(stream lp2pnetwork.Stream) {
 	from := stream.Conn().RemotePeer()
 
-	s.logger.Debug("receiving stream", "from", util.FingerprintPeerID(from))
+	s.logger.Debug("receiving stream", "from", from)
 	event := &StreamMessage{
 		Source: from,
 		Reader: stream,
@@ -52,7 +51,7 @@ func (s *streamService) handleStream(stream lp2pnetwork.Stream) {
 }
 
 func (s *streamService) SendRequest(msg []byte, pid lp2peer.ID) error {
-	s.logger.Debug("sending stream", "to", util.FingerprintPeerID(pid))
+	s.logger.Debug("sending stream", "to", pid)
 	_, err := s.host.Peerstore().SupportsProtocols(pid, string(s.protocolID))
 	if err != nil {
 		return errors.Errorf(errors.ErrNetwork, err.Error())

--- a/sync/bundle/bundle_test.go
+++ b/sync/bundle/bundle_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/zarbchain/zarb-go/block"
 	"github.com/zarbchain/zarb-go/consensus/vote"
+	"github.com/zarbchain/zarb-go/network"
 	"github.com/zarbchain/zarb-go/sync/bundle/message"
 	"github.com/zarbchain/zarb-go/util"
 )
 
 func TestNewMessage(t *testing.T) {
-	pid := util.RandomPeerID()
+	pid := network.TestRandomPeerID()
 	msg := NewBundle(pid, message.NewQueryProposalMessage(100, 0))
 	assert.Zero(t, msg.Flags)
 	assert.Equal(t, msg.Initiator, pid)
@@ -36,7 +37,7 @@ func TestMessageCompress(t *testing.T) {
 		blocks = append(blocks, b)
 	}
 	msg := message.NewBlocksResponseMessage(message.ResponseCodeBusy, 1234, 888, blocks, nil)
-	bdl := NewBundle(util.RandomPeerID(), msg)
+	bdl := NewBundle(network.TestRandomPeerID(), msg)
 	bs0, err := bdl.Encode()
 	assert.NoError(t, err)
 	bdl.CompressIt()
@@ -59,7 +60,7 @@ func TestMessageCompress(t *testing.T) {
 func TestDecodeVoteMessage(t *testing.T) {
 	v, _ := vote.GenerateTestPrecommitVote(88, 0)
 	msg := message.NewVoteMessage(v)
-	bdl := NewBundle(util.RandomPeerID(), msg)
+	bdl := NewBundle(network.TestRandomPeerID(), msg)
 	bs0, err := bdl.Encode()
 	assert.NoError(t, err)
 	bdl.CompressIt()

--- a/sync/bundle/message/hello_test.go
+++ b/sync/bundle/message/hello_test.go
@@ -3,7 +3,6 @@ package message
 import (
 	"testing"
 
-	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/assert"
 	"github.com/zarbchain/zarb-go/crypto/bls"
 	"github.com/zarbchain/zarb-go/crypto/hash"

--- a/sync/bundle/message/hello_test.go
+++ b/sync/bundle/message/hello_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/zarbchain/zarb-go/crypto/bls"
 	"github.com/zarbchain/zarb-go/crypto/hash"
 	"github.com/zarbchain/zarb-go/errors"
+	"github.com/zarbchain/zarb-go/network"
 )
 
 func TestHelloType(t *testing.T) {
@@ -18,7 +19,7 @@ func TestHelloType(t *testing.T) {
 func TestHelloMessage(t *testing.T) {
 	t.Run("Invalid height", func(t *testing.T) {
 		signer := bls.GenerateTestSigner()
-		m := NewHelloMessage(peer.ID("oscar-peer-id"), "Oscar", -1, 0, hash.GenerateTestHash())
+		m := NewHelloMessage(network.TestRandomPeerID(), "Oscar", -1, 0, hash.GenerateTestHash())
 		signer.SignMsg(m)
 
 		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidHeight)
@@ -27,7 +28,7 @@ func TestHelloMessage(t *testing.T) {
 	t.Run("Invalid signature", func(t *testing.T) {
 		signer1 := bls.GenerateTestSigner()
 		signer2 := bls.GenerateTestSigner()
-		m := NewHelloMessage(peer.ID("oscar-peer-id"), "Oscar", 100, 0, hash.GenerateTestHash())
+		m := NewHelloMessage(network.TestRandomPeerID(), "Oscar", 100, 0, hash.GenerateTestHash())
 		signer1.SignMsg(m)
 		m.SetPublicKey(signer2.PublicKey())
 
@@ -36,7 +37,7 @@ func TestHelloMessage(t *testing.T) {
 
 	t.Run("Ok", func(t *testing.T) {
 		signer := bls.GenerateTestSigner()
-		m := NewHelloMessage(peer.ID("alice-peer-id"), "Alice", 100, 0, hash.GenerateTestHash())
+		m := NewHelloMessage(network.TestRandomPeerID(), "Alice", 100, 0, hash.GenerateTestHash())
 		signer.SignMsg(m)
 
 		assert.NoError(t, m.SanityCheck())

--- a/sync/bundle/message/hello_test.go
+++ b/sync/bundle/message/hello_test.go
@@ -3,11 +3,11 @@ package message
 import (
 	"testing"
 
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/assert"
 	"github.com/zarbchain/zarb-go/crypto/bls"
 	"github.com/zarbchain/zarb-go/crypto/hash"
 	"github.com/zarbchain/zarb-go/errors"
-	"github.com/zarbchain/zarb-go/util"
 )
 
 func TestHelloType(t *testing.T) {
@@ -18,24 +18,25 @@ func TestHelloType(t *testing.T) {
 func TestHelloMessage(t *testing.T) {
 	t.Run("Invalid height", func(t *testing.T) {
 		signer := bls.GenerateTestSigner()
-		m := NewHelloMessage(util.RandomPeerID(), "Oscar", -1, 0, hash.GenerateTestHash())
+		m := NewHelloMessage(peer.ID("oscar-peer-id"), "Oscar", -1, 0, hash.GenerateTestHash())
 		signer.SignMsg(m)
 
 		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidHeight)
 	})
 
 	t.Run("Invalid signature", func(t *testing.T) {
-		signer := bls.GenerateTestSigner()
-		m := NewHelloMessage(util.RandomPeerID(), "Oscar", 100, 0, hash.GenerateTestHash())
-		signer.SignMsg(m)
+		signer1 := bls.GenerateTestSigner()
+		signer2 := bls.GenerateTestSigner()
+		m := NewHelloMessage(peer.ID("oscar-peer-id"), "Oscar", 100, 0, hash.GenerateTestHash())
+		signer1.SignMsg(m)
+		m.SetPublicKey(signer2.PublicKey())
 
-		m.PeerID = util.RandomPeerID()
 		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidSignature)
 	})
 
 	t.Run("Ok", func(t *testing.T) {
 		signer := bls.GenerateTestSigner()
-		m := NewHelloMessage(util.RandomPeerID(), "Alice", 100, 0, hash.GenerateTestHash())
+		m := NewHelloMessage(peer.ID("alice-peer-id"), "Alice", 100, 0, hash.GenerateTestHash())
 		signer.SignMsg(m)
 
 		assert.NoError(t, m.SanityCheck())

--- a/sync/firewall/firewall.go
+++ b/sync/firewall/firewall.go
@@ -37,7 +37,7 @@ func (f *Firewall) OpenGossipBundle(data []byte, source peer.ID, from peer.ID) *
 	if from != source {
 		f.peerSet.UpdateLastSeen(from)
 		if f.isPeerBanned(from) {
-			f.logger.Warn("firewall: from peer banned", "from", util.FingerprintPeerID(from))
+			f.logger.Warn("firewall: from peer banned", "from", from)
 			f.closeConnection(from)
 			return nil
 		}

--- a/sync/firewall/firewall_test.go
+++ b/sync/firewall/firewall_test.go
@@ -28,14 +28,14 @@ func setup(t *testing.T) {
 	logger := logger.NewLogger("firewal", nil)
 	peerSet := peerset.NewPeerSet(3 * time.Second)
 	tState = state.MockingState()
-	tNetwork = network.MockingNetwork(util.RandomPeerID())
+	tNetwork = network.MockingNetwork(network.TestRandomPeerID())
 	conf := TestConfig()
 	conf.Enabled = true
 	tFirewall = NewFirewall(conf, tNetwork, peerSet, tState, logger)
 	assert.NotNil(t, tFirewall)
-	tBadPeerID = util.RandomPeerID()
-	tGoodPeerID = util.RandomPeerID()
-	tUnknownPeerID = util.RandomPeerID()
+	tBadPeerID = network.TestRandomPeerID()
+	tGoodPeerID = network.TestRandomPeerID()
+	tUnknownPeerID = network.TestRandomPeerID()
 
 	tNetwork.AddAnotherNetwork(network.MockingNetwork(tGoodPeerID))
 	tNetwork.AddAnotherNetwork(network.MockingNetwork(tUnknownPeerID))

--- a/sync/handler_block_announce.go
+++ b/sync/handler_block_announce.go
@@ -18,7 +18,7 @@ func newBlockAnnounceHandler(sync *synchronizer) messageHandler {
 
 func (handler *blockAnnounceHandler) ParsMessage(m message.Message, initiator peer.ID) error {
 	msg := m.(*message.BlockAnnounceMessage)
-	handler.logger.Trace("parsing BlockAnnounce message", "msg", msg)
+	handler.logger.Trace("parsing BlockAnnounce message", "message", msg)
 
 	handler.cache.AddCertificate(msg.Height, msg.Certificate)
 	handler.cache.AddBlock(msg.Height, msg.Block)

--- a/sync/handler_block_announce_test.go
+++ b/sync/handler_block_announce_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/zarbchain/zarb-go/block"
 	"github.com/zarbchain/zarb-go/crypto/bls"
+	"github.com/zarbchain/zarb-go/network"
 	"github.com/zarbchain/zarb-go/sync/bundle/message"
-	"github.com/zarbchain/zarb-go/util"
 )
 
 func TestParsingBlockAnnounceMessages(t *testing.T) {
@@ -20,7 +20,7 @@ func TestParsingBlockAnnounceMessages(t *testing.T) {
 	b2 := block.GenerateTestBlock(nil, &lastBlockHash)
 	c2 := block.GenerateTestCertificate(b2.Hash())
 
-	pid := util.RandomPeerID()
+	pid := network.TestRandomPeerID()
 	msg := message.NewBlockAnnounceMessage(lastBlockheight+2, b2, c2)
 
 	pub, _ := bls.GenerateTestKeyPair()

--- a/sync/handler_blocks_request.go
+++ b/sync/handler_blocks_request.go
@@ -19,10 +19,10 @@ func newBlocksRequestHandler(sync *synchronizer) messageHandler {
 
 func (handler *blocksRequestHandler) ParsMessage(m message.Message, initiator peer.ID) error {
 	msg := m.(*message.BlocksRequestMessage)
-	handler.logger.Trace("parsing BlocksRequest message", "msg", msg)
+	handler.logger.Trace("parsing BlocksRequest message", "message", msg)
 
 	if handler.peerSet.NumberOfOpenSessions() > handler.config.MaximumOpenSessions {
-		handler.logger.Warn("we are busy", "msg", msg, "pid", initiator)
+		handler.logger.Warn("we are busy", "message", msg, "pid", initiator)
 		response := message.NewBlocksResponseMessage(message.ResponseCodeBusy, msg.SessionID, 0, nil, nil)
 		handler.sendTo(response, initiator)
 

--- a/sync/handler_blocks_request_test.go
+++ b/sync/handler_blocks_request_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zarbchain/zarb-go/crypto/bls"
+	"github.com/zarbchain/zarb-go/network"
 	"github.com/zarbchain/zarb-go/sync/bundle/message"
 	"github.com/zarbchain/zarb-go/util"
 )
@@ -17,7 +18,7 @@ func TestSessionTimeout(t *testing.T) {
 
 	t.Run("An unknown peers claims to have more blocks. Session should be closed after timeout", func(t *testing.T) {
 		signer := bls.GenerateTestSigner()
-		pid := util.RandomPeerID()
+		pid := network.TestRandomPeerID()
 		msg := message.NewHelloMessage(pid, "Oscar", 6666, message.FlagNodeNetwork, tState.GenesisHash())
 		signer.SignMsg(msg)
 
@@ -36,7 +37,7 @@ func TestLatestBlocksRequestMessages(t *testing.T) {
 	setup(t)
 
 	sid := int(util.RandInt32(100))
-	pid := util.RandomPeerID()
+	pid := network.TestRandomPeerID()
 
 	t.Run("Reject request from unknown peers", func(t *testing.T) {
 		msg := message.NewBlocksRequestMessage(sid, 100, 105)
@@ -104,11 +105,11 @@ func TestLatestBlocksRequestMessages(t *testing.T) {
 	})
 
 	t.Run("Peer is busy", func(t *testing.T) {
-		tSync.peerSet.OpenSession(util.RandomPeerID())
-		tSync.peerSet.OpenSession(util.RandomPeerID())
-		tSync.peerSet.OpenSession(util.RandomPeerID())
-		tSync.peerSet.OpenSession(util.RandomPeerID())
-		tSync.peerSet.OpenSession(util.RandomPeerID())
+		tSync.peerSet.OpenSession(network.TestRandomPeerID())
+		tSync.peerSet.OpenSession(network.TestRandomPeerID())
+		tSync.peerSet.OpenSession(network.TestRandomPeerID())
+		tSync.peerSet.OpenSession(network.TestRandomPeerID())
+		tSync.peerSet.OpenSession(network.TestRandomPeerID())
 		require.Equal(t, tSync.peerSet.NumberOfOpenSessions(), 5)
 
 		s := tSync.peerSet.OpenSession(tNetwork.SelfID())

--- a/sync/handler_blocks_response.go
+++ b/sync/handler_blocks_response.go
@@ -18,7 +18,7 @@ func newBlocksResponseHandler(sync *synchronizer) messageHandler {
 
 func (handler *blocksResponseHandler) ParsMessage(m message.Message, initiator peer.ID) error {
 	msg := m.(*message.BlocksResponseMessage)
-	handler.logger.Trace("parsing BlocksResponse message", "msg", msg)
+	handler.logger.Trace("parsing BlocksResponse message", "message", msg)
 
 	if msg.IsRequestRejected() {
 		handler.logger.Warn("blocks request is rejected", "pid", initiator, "response", msg.ResponseCode)

--- a/sync/handler_blocks_response_test.go
+++ b/sync/handler_blocks_response_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/zarbchain/zarb-go/network"
 	"github.com/zarbchain/zarb-go/state"
 	"github.com/zarbchain/zarb-go/sync/bundle/message"
-	"github.com/zarbchain/zarb-go/util"
 )
 
 func TestOneBlockShorter(t *testing.T) {
@@ -22,7 +21,7 @@ func TestOneBlockShorter(t *testing.T) {
 	lastBlockheight := tState.LastBlockHeight()
 	b1 := block.GenerateTestBlock(nil, &lastBlockHash)
 	c1 := block.GenerateTestCertificate(b1.Hash())
-	pid := util.RandomPeerID()
+	pid := network.TestRandomPeerID()
 
 	pub, _ := bls.GenerateTestKeyPair()
 	testAddPeer(t, pub, pid)
@@ -66,8 +65,8 @@ func TestSyncing(t *testing.T) {
 	consensusBob := consensus.MockingConsensus(stateBob)
 	broadcastChAlice := make(chan message.Message, 1000)
 	broadcastChBob := make(chan message.Message, 1000)
-	networkAlice := network.MockingNetwork(util.RandomPeerID())
-	networkBob := network.MockingNetwork(util.RandomPeerID())
+	networkAlice := network.MockingNetwork(network.TestRandomPeerID())
+	networkBob := network.MockingNetwork(network.TestRandomPeerID())
 
 	LatestBlockInterval = 30
 	configBob.NodeNetwork = true

--- a/sync/handler_heart_beat.go
+++ b/sync/handler_heart_beat.go
@@ -18,7 +18,7 @@ func newHeartBeatHandler(sync *synchronizer) messageHandler {
 
 func (handler *heartBeatHandler) ParsMessage(m message.Message, initiator peer.ID) error {
 	msg := m.(*message.HeartBeatMessage)
-	handler.logger.Trace("parsing HeartBeat message", "msg", msg)
+	handler.logger.Trace("parsing HeartBeat message", "message", msg)
 
 	height, round := handler.consensus.HeightRound()
 

--- a/sync/handler_heart_beat_test.go
+++ b/sync/handler_heart_beat_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/zarbchain/zarb-go/consensus/vote"
 	"github.com/zarbchain/zarb-go/crypto/hash"
+	"github.com/zarbchain/zarb-go/network"
 	"github.com/zarbchain/zarb-go/sync/bundle/message"
-	"github.com/zarbchain/zarb-go/util"
 )
 
 func TestParsingHeartbeatMessages(t *testing.T) {
@@ -15,7 +15,7 @@ func TestParsingHeartbeatMessages(t *testing.T) {
 
 	tConsensus.Round = 1
 	h, _ := tConsensus.HeightRound()
-	pid := util.RandomPeerID()
+	pid := network.TestRandomPeerID()
 	msg := message.NewHeartBeatMessage(h, 2, hash.GenerateTestHash())
 
 	t.Run("Not in the committee, but processes hearbeat messages", func(t *testing.T) {

--- a/sync/handler_hello.go
+++ b/sync/handler_hello.go
@@ -21,7 +21,7 @@ func newHelloHandler(sync *synchronizer) messageHandler {
 
 func (handler *helloHandler) ParsMessage(m message.Message, initiator peer.ID) error {
 	msg := m.(*message.HelloMessage)
-	handler.logger.Trace("parsing Hello message", "msg", msg)
+	handler.logger.Trace("parsing Hello message", "message", msg)
 
 	if msg.PeerID != initiator {
 		handler.peerSet.UpdateStatus(initiator, peerset.StatusCodeBanned)

--- a/sync/handler_hello_test.go
+++ b/sync/handler_hello_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/zarbchain/zarb-go/crypto/bls"
 	"github.com/zarbchain/zarb-go/crypto/hash"
+	"github.com/zarbchain/zarb-go/network"
 	"github.com/zarbchain/zarb-go/sync/bundle"
 	"github.com/zarbchain/zarb-go/sync/bundle/message"
 	"github.com/zarbchain/zarb-go/sync/peerset"
@@ -18,8 +19,8 @@ func TestParsingHelloMessages(t *testing.T) {
 
 	t.Run("Receiving Hello message from a peer. Peer ID is not same as initiator.", func(t *testing.T) {
 		signer := bls.GenerateTestSigner()
-		pid := util.RandomPeerID()
-		initiator := util.RandomPeerID()
+		pid := network.TestRandomPeerID()
+		initiator := network.TestRandomPeerID()
 		msg := message.NewHelloMessage(pid, "bad-genesis", 0, 0, tState.GenesisHash())
 		signer.SignMsg(msg)
 		assert.True(t, msg.PublicKey.EqualsTo(signer.PublicKey()))
@@ -31,7 +32,7 @@ func TestParsingHelloMessages(t *testing.T) {
 	t.Run("Receiving Hello message from a peer. Genesis hash is wrong.", func(t *testing.T) {
 		invGenHash := hash.GenerateTestHash()
 		signer := bls.GenerateTestSigner()
-		pid := util.RandomPeerID()
+		pid := network.TestRandomPeerID()
 		msg := message.NewHelloMessage(pid, "bad-genesis", 0, 0, invGenHash)
 		signer.SignMsg(msg)
 		assert.True(t, msg.PublicKey.EqualsTo(signer.PublicKey()))
@@ -44,7 +45,7 @@ func TestParsingHelloMessages(t *testing.T) {
 	t.Run("Receiving Hello message from a peer. It should be acknowledged and updates the peer info", func(t *testing.T) {
 		signer := bls.GenerateTestSigner()
 		height := util.RandInt32(0)
-		pid := util.RandomPeerID()
+		pid := network.TestRandomPeerID()
 		msg := message.NewHelloMessage(pid, "kitty", height, message.FlagNodeNetwork, tState.GenesisHash())
 		signer.SignMsg(msg)
 
@@ -65,7 +66,7 @@ func TestParsingHelloMessages(t *testing.T) {
 
 	t.Run("Receiving Hello-ack message from a peer. It should not be acknowledged, but update the peer info", func(t *testing.T) {
 		signer := bls.GenerateTestSigner()
-		pid := util.RandomPeerID()
+		pid := network.TestRandomPeerID()
 		msg := message.NewHelloMessage(pid, "kitty", 0, message.FlagHelloAck, tState.GenesisHash())
 		signer.SignMsg(msg)
 
@@ -78,7 +79,7 @@ func TestParsingHelloMessages(t *testing.T) {
 		tSync.peerSet.Clear()
 		signer := bls.GenerateTestSigner()
 		claimedHeight := tState.LastBlockHeight() + 5
-		pid := util.RandomPeerID()
+		pid := network.TestRandomPeerID()
 		msg := message.NewHelloMessage(pid, "kitty", claimedHeight, message.FlagHelloAck, tState.GenesisHash())
 		signer.SignMsg(msg)
 

--- a/sync/handler_proposal.go
+++ b/sync/handler_proposal.go
@@ -18,7 +18,7 @@ func newProposalHandler(sync *synchronizer) messageHandler {
 
 func (handler *proposalHandler) ParsMessage(m message.Message, initiator peer.ID) error {
 	msg := m.(*message.ProposalMessage)
-	handler.logger.Trace("parsing Proposal message", "msg", msg)
+	handler.logger.Trace("parsing Proposal message", "message", msg)
 
 	handler.cache.AddProposal(msg.Proposal)
 	handler.consensus.SetProposal(msg.Proposal)

--- a/sync/handler_proposal_test.go
+++ b/sync/handler_proposal_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/zarbchain/zarb-go/consensus/proposal"
+	"github.com/zarbchain/zarb-go/network"
 	"github.com/zarbchain/zarb-go/sync/bundle/message"
-	"github.com/zarbchain/zarb-go/util"
 )
 
 func TestParsingProposalMessages(t *testing.T) {
@@ -17,7 +17,7 @@ func TestParsingProposalMessages(t *testing.T) {
 		prop, _ := proposal.GenerateTestProposal(consensusHeight, 0)
 		msg := message.NewProposalMessage(prop)
 
-		assert.NoError(t, testReceiveingNewMessage(tSync, msg, util.RandomPeerID()))
+		assert.NoError(t, testReceiveingNewMessage(tSync, msg, network.TestRandomPeerID()))
 		assert.NotNil(t, tSync.cache.GetProposal(consensusHeight, 0))
 		assert.NotNil(t, tConsensus.RoundProposal(0))
 	})

--- a/sync/handler_query_proposal.go
+++ b/sync/handler_query_proposal.go
@@ -19,7 +19,7 @@ func newQueryProposalHandler(sync *synchronizer) messageHandler {
 
 func (handler *queryProposalHandler) ParsMessage(m message.Message, initiator peer.ID) error {
 	msg := m.(*message.QueryProposalMessage)
-	handler.logger.Trace("parsing QueryProposal message", "msg", msg)
+	handler.logger.Trace("parsing QueryProposal message", "message", msg)
 
 	height, round := handler.consensus.HeightRound()
 	if msg.Height == height && msg.Round == round {
@@ -50,7 +50,7 @@ func (handler *queryProposalHandler) PrepareBundle(m message.Message) *bundle.Bu
 				msg := bundle.NewBundle(handler.SelfID(), m)
 				return msg
 			}
-			handler.logger.Debug("not an active validator", "msg", msg)
+			handler.logger.Debug("not an active validator", "message", msg)
 		}
 	}
 

--- a/sync/handler_query_proposal_test.go
+++ b/sync/handler_query_proposal_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/zarbchain/zarb-go/consensus/proposal"
+	"github.com/zarbchain/zarb-go/network"
 	"github.com/zarbchain/zarb-go/sync/bundle/message"
-	"github.com/zarbchain/zarb-go/util"
 )
 
 func TestParsingQueryProposalMessages(t *testing.T) {
@@ -14,7 +14,7 @@ func TestParsingQueryProposalMessages(t *testing.T) {
 
 	consensusHeight := tState.LastBlockHeight() + 1
 	prop, _ := proposal.GenerateTestProposal(consensusHeight, 0)
-	pid := util.RandomPeerID()
+	pid := network.TestRandomPeerID()
 	msg := message.NewQueryProposalMessage(consensusHeight, 0)
 	tConsensus.SetProposal(prop)
 

--- a/sync/handler_query_votes.go
+++ b/sync/handler_query_votes.go
@@ -19,7 +19,7 @@ func newQueryVotesHandler(sync *synchronizer) messageHandler {
 
 func (handler *queryVotesHandler) ParsMessage(m message.Message, initiator peer.ID) error {
 	msg := m.(*message.QueryVotesMessage)
-	handler.logger.Trace("parsing QueryVotes message", "msg", msg)
+	handler.logger.Trace("parsing QueryVotes message", "message", msg)
 
 	height, _ := handler.consensus.HeightRound()
 	if msg.Height == height {

--- a/sync/handler_query_votes_test.go
+++ b/sync/handler_query_votes_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/zarbchain/zarb-go/consensus/vote"
+	"github.com/zarbchain/zarb-go/network"
 	"github.com/zarbchain/zarb-go/sync/bundle/message"
-	"github.com/zarbchain/zarb-go/util"
 )
 
 func TestParsingQueryVotesMessages(t *testing.T) {
@@ -15,7 +15,7 @@ func TestParsingQueryVotesMessages(t *testing.T) {
 	consensusHeight := tState.LastBlockHeight() + 1
 	v1, _ := vote.GenerateTestPrecommitVote(consensusHeight, 0)
 	tConsensus.AddVote(v1)
-	pid := util.RandomPeerID()
+	pid := network.TestRandomPeerID()
 	msg := message.NewQueryVotesMessage(consensusHeight, 1)
 
 	t.Run("Not in the committee, should not respond to the query vote message", func(t *testing.T) {

--- a/sync/handler_transactions.go
+++ b/sync/handler_transactions.go
@@ -18,7 +18,7 @@ func newTransactionsHandler(sync *synchronizer) messageHandler {
 
 func (handler *transactionsHandler) ParsMessage(m message.Message, initiator peer.ID) error {
 	msg := m.(*message.TransactionsMessage)
-	handler.logger.Trace("parsing Transactions message", "msg", msg)
+	handler.logger.Trace("parsing Transactions message", "message", msg)
 
 	for _, trx := range msg.Transactions {
 		if err := handler.state.AddPendingTx(trx); err != nil {

--- a/sync/handler_transactions_test.go
+++ b/sync/handler_transactions_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/zarbchain/zarb-go/network"
 	"github.com/zarbchain/zarb-go/sync/bundle/message"
 	"github.com/zarbchain/zarb-go/tx"
-	"github.com/zarbchain/zarb-go/util"
 )
 
 func TestParsingTransactionsMessages(t *testing.T) {
@@ -16,7 +16,7 @@ func TestParsingTransactionsMessages(t *testing.T) {
 		trx1, _ := tx.GenerateTestBondTx()
 		msg := message.NewTransactionsMessage([]*tx.Tx{trx1})
 
-		assert.NoError(t, testReceiveingNewMessage(tSync, msg, util.RandomPeerID()))
+		assert.NoError(t, testReceiveingNewMessage(tSync, msg, network.TestRandomPeerID()))
 
 		assert.NotNil(t, tSync.state.PendingTx(trx1.ID()))
 	})

--- a/sync/handler_vote.go
+++ b/sync/handler_vote.go
@@ -18,7 +18,7 @@ func newVoteHandler(sync *synchronizer) messageHandler {
 
 func (handler *voteHandler) ParsMessage(m message.Message, initiator peer.ID) error {
 	msg := m.(*message.VoteMessage)
-	handler.logger.Trace("parsing Vote message", "msg", msg)
+	handler.logger.Trace("parsing Vote message", "message", msg)
 
 	handler.consensus.AddVote(msg.Vote)
 

--- a/sync/handler_vote_test.go
+++ b/sync/handler_vote_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/zarbchain/zarb-go/consensus/vote"
+	"github.com/zarbchain/zarb-go/network"
 	"github.com/zarbchain/zarb-go/sync/bundle/message"
-	"github.com/zarbchain/zarb-go/util"
 )
 
 func TestParsingVoteMessages(t *testing.T) {
@@ -16,7 +16,7 @@ func TestParsingVoteMessages(t *testing.T) {
 		v, _ := vote.GenerateTestPrecommitVote(1, 0)
 		msg := message.NewVoteMessage(v)
 
-		assert.NoError(t, testReceiveingNewMessage(tSync, msg, util.RandomPeerID()))
+		assert.NoError(t, testReceiveingNewMessage(tSync, msg, network.TestRandomPeerID()))
 		assert.Equal(t, tConsensus.Votes[0].Hash(), v.Hash())
 	})
 }

--- a/sync/mock.go
+++ b/sync/mock.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/zarbchain/zarb-go/crypto/bls"
+	"github.com/zarbchain/zarb-go/network"
 	"github.com/zarbchain/zarb-go/sync/peerset"
 	"github.com/zarbchain/zarb-go/util"
 	"github.com/zarbchain/zarb-go/version"
@@ -21,8 +22,8 @@ func MockingSync() *MockSync {
 	ps := peerset.NewPeerSet(1 * time.Second)
 	pub1, _ := bls.GenerateTestKeyPair()
 	pub2, _ := bls.GenerateTestKeyPair()
-	pid1 := util.RandomPeerID()
-	pid2 := util.RandomPeerID()
+	pid1 := network.TestRandomPeerID()
+	pid2 := network.TestRandomPeerID()
 	ps.UpdatePeerInfo(
 		pid1,
 		peerset.StatusCodeKnown,
@@ -42,7 +43,7 @@ func MockingSync() *MockSync {
 	ps.UpdateHeight(pid1, util.RandInt32(100000))
 
 	return &MockSync{
-		ID:      util.RandomPeerID(),
+		ID:      network.TestRandomPeerID(),
 		PeerSet: ps,
 	}
 }

--- a/sync/peerset/peer.go
+++ b/sync/peerset/peer.go
@@ -1,7 +1,6 @@
 package peerset
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -35,12 +34,6 @@ func NewPeer(peerID peer.ID) *Peer {
 		Status: StatusCodeUnknown,
 		PeerID: peerID,
 	}
-}
-
-func (p *Peer) Fingerprint() string {
-	return fmt.Sprintf("{%v %v}",
-		util.FingerprintPeerID(p.PeerID),
-		p.Height)
 }
 
 func (p *Peer) IsKnownOrTrusty() bool {

--- a/sync/peerset/session.go
+++ b/sync/peerset/session.go
@@ -1,7 +1,6 @@
 package peerset
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -59,13 +58,4 @@ func (s *Session) LastActivityAt() time.Time {
 	defer s.lk.RUnlock()
 
 	return s.data.LastActivityAt
-}
-
-func (s *Session) Fingerprint() string {
-	s.lk.RLock()
-	defer s.lk.RUnlock()
-
-	return fmt.Sprintf("{id %d %v}",
-		s.data.SessionID,
-		util.FingerprintPeerID(s.data.PeerID))
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -219,7 +219,7 @@ func (sync *synchronizer) receiveLoop() {
 
 			err := sync.processIncomingBundle(bdl)
 			if err != nil {
-				sync.logger.Warn("error on parsing a message", "initiator", bdl.Initiator, "message", bdl, "err", err)
+				sync.logger.Warn("error on parsing a bundle", "initiator", bdl.Initiator, "bundle", bdl, "err", err)
 				sync.peerSet.IncreaseInvalidBundlesCounter(bdl.Initiator)
 			}
 		}
@@ -231,7 +231,7 @@ func (sync *synchronizer) processIncomingBundle(bdl *bundle.Bundle) error {
 		return nil
 	}
 
-	sync.logger.Debug("received a message", "initiator", bdl.Initiator, "bundle", bdl)
+	sync.logger.Debug("received a bundle", "initiator", bdl.Initiator, "bundle", bdl)
 	h := sync.handlers[bdl.Message.Type()]
 	if h == nil {
 		return errors.Errorf(errors.ErrInvalidMessage, "invalid message type: %v", bdl.Message.Type())
@@ -312,9 +312,9 @@ func (sync *synchronizer) sendTo(msg message.Message, to peer.ID) {
 		data, _ := bdl.Encode()
 		err := sync.network.SendTo(data, to)
 		if err != nil {
-			sync.logger.Error("error on sending message", "message", bdl, "err", err)
+			sync.logger.Error("error on sending bundle", "bundle", bdl, "err", err)
 		} else {
-			sync.logger.Debug("sending message to a peer", "message", bdl, "to", to)
+			sync.logger.Debug("sending bundle to a peer", "bundle", bdl, "to", to)
 		}
 	}
 }
@@ -326,9 +326,9 @@ func (sync *synchronizer) broadcast(msg message.Message) {
 		data, _ := bdl.Encode()
 		err := sync.network.Broadcast(data, msg.Type().TopicID())
 		if err != nil {
-			sync.logger.Error("error on broadcasting message", "message", msg, "err", err)
+			sync.logger.Error("error on broadcasting bundle", "bundle", bdl, "err", err)
 		} else {
-			sync.logger.Debug("broadcasting new message", "message", msg)
+			sync.logger.Debug("broadcasting new bundle", "bundle", bdl)
 		}
 	}
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -219,7 +219,7 @@ func (sync *synchronizer) receiveLoop() {
 
 			err := sync.processIncomingBundle(bdl)
 			if err != nil {
-				sync.logger.Warn("error on parsing a message", "initiator", util.FingerprintPeerID(bdl.Initiator), "message", bdl, "err", err)
+				sync.logger.Warn("error on parsing a message", "initiator", bdl.Initiator, "message", bdl, "err", err)
 				sync.peerSet.IncreaseInvalidBundlesCounter(bdl.Initiator)
 			}
 		}
@@ -231,7 +231,7 @@ func (sync *synchronizer) processIncomingBundle(bdl *bundle.Bundle) error {
 		return nil
 	}
 
-	sync.logger.Debug("received a message", "initiator", util.FingerprintPeerID(bdl.Initiator), "bundle", bdl)
+	sync.logger.Debug("received a message", "initiator", bdl.Initiator, "bundle", bdl)
 	h := sync.handlers[bdl.Message.Type()]
 	if h == nil {
 		return errors.Errorf(errors.ErrInvalidMessage, "invalid message type: %v", bdl.Message.Type())
@@ -372,7 +372,7 @@ func (sync *synchronizer) downloadBlocks(from int32) {
 			to = peer.Height
 		}
 
-		sync.logger.Debug("sending download request", "from", from+1, "to", to, "pid", util.FingerprintPeerID(peer.PeerID))
+		sync.logger.Debug("sending download request", "from", from+1, "to", to, "pid", peer.PeerID)
 		session := sync.peerSet.OpenSession(peer.PeerID)
 		msg := message.NewBlocksRequestMessage(session.SessionID(), from+1, to)
 		sync.sendTo(msg, peer.PeerID)
@@ -394,7 +394,7 @@ func (sync *synchronizer) queryLatestBlocks(from int32) {
 		return
 	}
 
-	sync.logger.Debug("querying the latest blocks", "from", from+1, "to", to, "pid", util.FingerprintPeerID(randPeer.PeerID))
+	sync.logger.Debug("querying the latest blocks", "from", from+1, "to", to, "pid", randPeer.PeerID)
 	session := sync.peerSet.OpenSession(randPeer.PeerID)
 	msg := message.NewBlocksRequestMessage(session.SessionID(), from+1, to)
 	sync.sendTo(msg, randPeer.PeerID)

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -54,7 +54,7 @@ func setup(t *testing.T) {
 	tState = state.MockingState()
 	tConsensus = consensus.MockingConsensus(tState)
 	tBroadcastCh = make(chan message.Message, 1000)
-	tNetwork = network.MockingNetwork(util.RandomPeerID())
+	tNetwork = network.MockingNetwork(network.TestRandomPeerID())
 
 	testAddBlocks(t, tState, 21)
 

--- a/txpool/pool_test.go
+++ b/txpool/pool_test.go
@@ -45,7 +45,7 @@ func shouldPublishTransaction(t *testing.T, id tx.ID) {
 			require.NoError(t, fmt.Errorf("Timeout"))
 			return
 		case msg := <-tCh:
-			logger.Info("shouldPublishTransaction", "msg", msg)
+			logger.Info("shouldPublishTransaction", "message", msg)
 
 			if msg.Type() == message.MessageTypeTransactions {
 				m := msg.(*message.TransactionsMessage)

--- a/util/utils.go
+++ b/util/utils.go
@@ -2,10 +2,7 @@ package util
 
 import (
 	crand "crypto/rand"
-	"fmt"
 	"math/big"
-
-	"github.com/libp2p/go-libp2p-core/peer"
 )
 
 const MaxUint16 = ^uint16(0)
@@ -96,21 +93,6 @@ func RandUint64(max uint64) uint64 {
 	bigMax.SetUint64(max)
 	bigRnd, _ := crand.Int(crand.Reader, bigMax)
 	return bigRnd.Uint64()
-}
-
-/// RandomPeerID returns a random peer ID
-func RandomPeerID() peer.ID {
-	s := Uint64ToSlice(RandUint64(MaxUint64))
-	id := [34]byte{0x12, 32}
-	copy(id[2:], s[:])
-	return peer.ID(id[:])
-
-}
-
-/// FingerprintPeerID returns a pretty and short string for the given peer ID
-func FingerprintPeerID(id peer.ID) string {
-	pid := id.Pretty()
-	return fmt.Sprintf("%s*%s", pid[:2], pid[len(pid)-6:])
 }
 
 /// SetFlag applies mask to the flags

--- a/util/utils_test.go
+++ b/util/utils_test.go
@@ -36,11 +36,6 @@ func TestSetFlags(t *testing.T) {
 	assert.Equal(t, flags, 0x8)
 }
 
-func TestRandomPeerID(t *testing.T) {
-	id := RandomPeerID()
-	assert.NoError(t, id.Validate())
-}
-
 func TestRandUint16(t *testing.T) {
 	rnd := RandUint16(4)
 	assert.GreaterOrEqual(t, rnd, uint16(0))


### PR DESCRIPTION
## Description

Removing `FingerprintPeerID` method from `utils`, This will reduce the dependency tree for `utils` package.

## Checklist
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] CHANGELOG is updated.
