### PR TITLE
Adding key info for keygen

### DIFF
--- a/cmd/zarbd/init.go
+++ b/cmd/zarbd/init.go
@@ -47,7 +47,7 @@ func Init() func(c *cli.Cmd) {
 			entropy, _ := bip39.NewEntropy(128)
 			mnemonic, _ := bip39.NewMnemonic(entropy)
 			seed := bip39.NewSeed(mnemonic, "")
-			prv, err := bls.PrivateKeyFromSeed(seed)
+			prv, err := bls.PrivateKeyFromSeed(seed, nil)
 			if err != nil {
 				cmd.PrintErrorMsg("Failed to create key from the seed: %v", err)
 				return

--- a/crypto/bls/private_key_test.go
+++ b/crypto/bls/private_key_test.go
@@ -74,6 +74,10 @@ func TestPrivateKeyFromSeed(t *testing.T) {
 			"0000000000000000000000000000000000000000000000000000000000000000",
 			"4d129a19df86a0f5345bad4cc6f249ec2a819ccc3386895beb4f7d98b3db6235",
 		},
+		{
+			"2b1eb88002e83a622792d0b96d4f0695e328f49fdd32480ec0cf39c2c76463af",
+			"0000f678e80740072a4a7fe8c7344db88a00ccc7db36aa51fa51f9c68e561584",
+		},
 		/// The test vectors from EIP-2333
 		/// https://github.com/ethereum/EIPs/blob/784107449bd83a9327b54f82aba96de28d72b89a/EIPS/eip-2333.md#test-cases
 		{
@@ -96,7 +100,7 @@ func TestPrivateKeyFromSeed(t *testing.T) {
 
 	for i, test := range tests {
 		ikm, _ := hex.DecodeString(test.ikm)
-		prv, err := PrivateKeyFromSeed(ikm)
+		prv, err := PrivateKeyFromSeed(ikm, nil)
 		if test.sk == "Err" {
 			assert.Error(t, err, "test #i failed", i)
 		} else {

--- a/keystore/key/key.go
+++ b/keystore/key/key.go
@@ -16,7 +16,7 @@ type keyData struct {
 }
 
 func FromSeed(seed []byte) (*Key, error) {
-	prv, err := bls.PrivateKeyFromSeed(seed)
+	prv, err := bls.PrivateKeyFromSeed(seed, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

- Adding `keyInfo` parameter for `KeyGen` function, Default is nil.
- Make sure the SecretKey is always 32 bytes

## Checklist
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] CHANGELOG is updated.
