### PR TITLE
Update release workflow to support macos dmg installer

### DIFF
--- a/.github/releasers/macos/Info.plist
+++ b/.github/releasers/macos/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.github.zarbchain.zarb-go.zarb-gui</string>
+    <key>CFBundleExecutable</key>
+    <string>zarb-gui</string>
+    <key>CFBundleName</key>
+    <string>zarb-gui</string>
+    <key>CFBundleShortVersionString</key>
+    <string>%SHORTVERSION%</string>
+    <key>CFBundleVersion</key>
+    <string>%VERSION%</string>
+<!--
+    <key>CFBundleIconFile</key>
+    <string>zarb.icns</string>
+-->
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>NSHumanReadableCopyright</key>
+    <string>MIT License.</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>10.15</string>
+</dict>
+</plist>

--- a/.github/releasers/macos/gui.bundle
+++ b/.github/releasers/macos/gui.bundle
@@ -1,0 +1,16 @@
+<?xml version="1.0" standalone="no"?>
+<app-bundle>
+  <meta>
+    <prefix name="default">/usr/local</prefix>
+    <prefix name="bundle">${env:GUI_BUNDLE}</prefix>
+    <destination overwrite="yes">${env:ROOT_DIR}</destination>
+    <gtk>gtk+-3.0</gtk>
+  </meta>
+  <plist>${prefix:bundle}/Info.plist</plist>
+  <main-binary>${prefix:bundle}/zarb-gui</main-binary>
+
+  <binary>
+    ${prefix}/lib/gdk-pixbuf-2.0/${pkg:gdk-pixbuf-2.0:gdk_pixbuf_binary_version}/loaders/*.so
+  </binary>
+
+  </app-bundle>

--- a/.github/releasers/releaser_macos.sh
+++ b/.github/releasers/releaser_macos.sh
@@ -12,6 +12,52 @@ echo "VERSION: $VERSION"
 echo "ROOT_DIR: $ROOT_DIR"
 echo "PACKAGE_DIR: $PACKAGE_DIR"
 
-mkdir ${PACKAGE_DIR}
-
 echo "Building the binaries"
+
+cd ${ROOT_DIR}
+make herumi
+export CGO_LDFLAGS="-L.herumi/bls/lib -lbls384_256 -lm -lstdc++ -g -O2"
+go build -ldflags "-s -w" -o ${BUILD_DIR}/zarb-daemon ./cmd/daemon
+go build -ldflags "-s -w" -o ${BUILD_DIR}/zarb-wallet ./cmd/wallet
+go build -ldflags "-s -w" -tags gtk -o ${BUILD_DIR}/zarb-gui ./cmd/gtk
+
+
+
+echo "Installing gtk-mac-bundler"
+git clone https://gitlab.gnome.org/GNOME/gtk-mac-bundler.git
+cd gtk-mac-bundler
+make install
+BUNDLER=${HOME}/.local/bin/gtk-mac-bundler
+cd -
+
+echo "Bundling the GUI package"
+GUI_BUNDLE=${ROOT_DIR}/gui-bundle
+mkdir ${GUI_BUNDLE}
+
+cp ${BUILD_DIR}/zarb-gui                  ${GUI_BUNDLE}
+cp ${ROOT_DIR}/.github/releasers/macos/*  ${GUI_BUNDLE}
+
+# https://stackoverflow.com/questions/21242932/sed-i-may-not-be-used-with-stdin-on-mac-os-x
+sed -i '' "s/%SHORTVERSION%/${VERSION}/"     ${GUI_BUNDLE}/Info.plist
+sed -i '' "s/%VERSION%/Version ${VERSION}/"  ${GUI_BUNDLE}/Info.plist
+
+export GUI_BUNDLE
+export ROOT_DIR
+
+${BUNDLER} ${GUI_BUNDLE}/gui.bundle
+
+
+echo "Creating dmg"
+# https://github.com/create-dmg/create-dmg
+create-dmg \
+  --volname "Zarb GUI" \
+  "${PACKAGE_NAME}-osx-64.dmg" \
+  "${ROOT_DIR}/zarb-gui.app"
+
+echo "Creating archive"
+mkdir ${PACKAGE_DIR}
+cp ${BUILD_DIR}/zarb-daemon     ${PACKAGE_DIR}
+cp ${BUILD_DIR}/zarb-wallet     ${PACKAGE_DIR}
+cp -R ${ROOT_DIR}/zarb-gui.app  ${PACKAGE_DIR}
+
+tar -czvf ${ROOT_DIR}/${PACKAGE_NAME}-osx-64.tar.gz -p ${PACKAGE_NAME}

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -32,12 +32,12 @@ jobs:
 
   ########################################
   build-macos:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v3
 
     - name: Install Dependencies
-      run: brew install gobject-introspection gtk+3 adwaita-icon-theme
+      run: brew install gtk+3 librsvg create-dmg
 
     - name: Install Go
       uses: actions/setup-go@v3
@@ -47,12 +47,14 @@ jobs:
     - name: Create release files
       run: bash ./.github/releasers/releaser_macos.sh
 
-    #- name: Publish
-    #  uses: softprops/action-gh-release@v1
-    #  with:
-    #    files: zarb-*tar.gz
-    #  env:
-    #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Publish
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          zarb-*.dmg
+          zarb-*.tar.gz
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   ########################################
   build-windows:


### PR DESCRIPTION
## Description

With this MR zarb-go repo could generate a dmg file with all of its dependencies installed using Github actions and workflow. it will enable users to install and run zarb-gui with one click.


## Checklist
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] CHANGELOG is updated.
