### PR TITLE
Generating different key for testnet

### DIFF
--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -70,9 +70,9 @@ func TestMain(m *testing.M) {
 		tConfigs[i].Sync.StartingTimeout = 0
 		tConfigs[i].Sync.NodeNetwork = false
 		tConfigs[i].Sync.Firewall.Enabled = false
+		tConfigs[i].Network.EnableMdns = true
 		tConfigs[i].Network.NodeKey = util.TempFilePath()
-		tConfigs[i].Network.Listens = []string{fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", 32125+i)}
-		tConfigs[i].Network.Bootstrap.Addresses = []string{"/ip4/127.0.0.1/tcp/32125/p2p/12D3KooWCKKGMMGDhqRUZh6MnH2to6XUN9N2YPof4LrNNMe5Mbek"}
+		tConfigs[i].Network.Listens = []string{"/ip4/127.0.0.1/tcp/0"}
 		tConfigs[i].Network.Bootstrap.Period = 10 * time.Second
 		tConfigs[i].Network.Bootstrap.MinThreshold = 3
 		tConfigs[i].HTTP.Enable = false
@@ -85,13 +85,6 @@ func TestMain(m *testing.M) {
 			tConfigs[i].Sync.NodeNetwork = true
 			tConfigs[i].Capnp.Enable = true
 			tConfigs[i].Capnp.Listen = tCapnpAddress
-
-			f, _ := os.Create(tConfigs[i].Network.NodeKey)
-			_, err := f.WriteString("08011240f22591817d8803e32525db7fc5cb9949d77c402e20867a6cac6b3ffb3dc643fb2521ef3c844a12eee79c275f19958999aeebb173496b67ea4a40f5d34b0a1355")
-			if err != nil {
-				panic(err)
-			}
-			f.Close()
 		}
 		fmt.Printf("Node %d address: %s\n", i+1, pub.Address())
 	}

--- a/wallet/vault/vault.go
+++ b/wallet/vault/vault.go
@@ -47,8 +47,7 @@ func GenerateMnemonic() string {
 	return mnemonic
 }
 
-func CreateVaultFromMnemonic(mnemonic, password string) (*Vault, error) {
-	keyInfo := []byte{} // TODO, update for testnet
+func CreateVaultFromMnemonic(mnemonic, password string, keyInfo []byte) (*Vault, error) {
 	parentSeed, err := bip39.NewSeedWithErrorChecking(mnemonic, "")
 	if err != nil {
 		return nil, err

--- a/wallet/vault/vault_test.go
+++ b/wallet/vault/vault_test.go
@@ -15,7 +15,7 @@ var tPassword string
 func setup(t *testing.T) {
 	password := "super_secret_password"
 	mnemonic := GenerateMnemonic()
-	vault, err := CreateVaultFromMnemonic(mnemonic, "")
+	vault, err := CreateVaultFromMnemonic(mnemonic, "", nil)
 	assert.NoError(t, err)
 	assert.False(t, vault.IsEncrypted())
 
@@ -76,12 +76,12 @@ func TestRecover(t *testing.T) {
 	password := ""
 
 	t.Run("Invalid mnemonic", func(t *testing.T) {
-		_, err := CreateVaultFromMnemonic("invali mnemonic phrase seed", password)
+		_, err := CreateVaultFromMnemonic("invali mnemonic phrase seed", password, nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("Ok", func(t *testing.T) {
-		recovered, err := CreateVaultFromMnemonic(mnemonic, password)
+		recovered, err := CreateVaultFromMnemonic(mnemonic, password, nil)
 		assert.NoError(t, err)
 
 		addr1, err := recovered.MakeNewAddress("", "addr-1")

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -71,7 +71,11 @@ func FromMnemonic(path, mnemonic, password string, net Network) (*Wallet, error)
 	if util.PathExists(path) {
 		return nil, NewErrWalletExits(path)
 	}
-	vault, err := vault.CreateVaultFromMnemonic(mnemonic, password)
+	keyInfo := []byte{}
+	if net == NetworkTestNet {
+		keyInfo = []byte{1}
+	}
+	vault, err := vault.CreateVaultFromMnemonic(mnemonic, password, keyInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -18,7 +18,7 @@ func setup(t *testing.T) {
 	tPassword := ""
 	walletPath := util.TempFilePath()
 	mnemonic := GenerateMnemonic()
-	w, err := FromMnemonic(walletPath, mnemonic, tPassword, 0)
+	w, err := FromMnemonic(walletPath, mnemonic, tPassword, NetworkMainNet)
 	assert.NoError(t, err)
 	assert.False(t, w.IsEncrypted())
 	assert.Equal(t, w.Path(), walletPath)
@@ -111,7 +111,8 @@ func TestSaveWallet(t *testing.T) {
 func TestInvalidAddress(t *testing.T) {
 	setup(t)
 
-	_, err := tWallet.PrivateKey(tPassword, crypto.GenerateTestAddress().String())
+	addr := crypto.GenerateTestAddress().String()
+	_, err := tWallet.PrivateKey(tPassword, addr)
 	assert.Error(t, err)
 }
 
@@ -127,7 +128,28 @@ func TestImportPrivateKey(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, pub, prv.PublicKey().String())
 }
+func TestTestKeyInfo(t *testing.T) {
+	mnemonic := GenerateMnemonic()
+	w1, err := FromMnemonic(util.TempFilePath(), mnemonic, tPassword,
+		NetworkMainNet)
+	assert.NoError(t, err)
+	addrStr1, _ := w1.MakeNewAddress("", "")
+	prvStr1, _ := w1.PrivateKey("", addrStr1)
+	prv1, _ := bls.PrivateKeyFromString(prvStr1)
+
+	w2, err := FromMnemonic(util.TempFilePath(), mnemonic, tPassword,
+		NetworkTestNet)
+	assert.NoError(t, err)
+	addrStr2, _ := w2.MakeNewAddress("", "")
+	prvStr2, _ := w2.PrivateKey("", addrStr2)
+	prv2, _ := bls.PrivateKeyFromString(prvStr2)
+
+	assert.NotEqual(t, prv1.Bytes(), prv2.Bytes(),
+		"Should generate different private key for the testnet")
+}
 
 func TestMakeSendTx(t *testing.T) {
 	setup(t)
+
+	//TODO
 }


### PR DESCRIPTION
## Description

`KeyInfo` for test net set to 1 to generate different key per network

## Checklist
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] CHANGELOG is updated.
